### PR TITLE
Add a fallback phylo_dist_path

### DIFF
--- a/gpn/star/logits.py
+++ b/gpn/star/logits.py
@@ -1,17 +1,16 @@
 import numpy as np
 import pandas as pd
 import torch
-from transformers import AutoModelForMaskedLM
 import os
 
-import gpn.star.model
+from gpn.star.model import load_model
 from gpn.data import Tokenizer
 
 
 class MLMforLogitsModel(torch.nn.Module):
     def __init__(self, model_path):
         super().__init__()
-        self.model = AutoModelForMaskedLM.from_pretrained(model_path)
+        self.model = load_model(model_path)
         self.model.eval()
         tokenizer = Tokenizer()
         self.id_a = tokenizer.vocab.index("A")

--- a/gpn/star/model.py
+++ b/gpn/star/model.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -958,6 +960,27 @@ class GPNStarForMaskedLM(GPNStarPreTrainedModel):
             loss=loss,
             logits=logits,
         )
+
+
+def load_model(model_path):
+    """Load model with validated phylo_dist_path.
+
+    If config.phylo_dist_path doesn't exist on filesystem, tries fallback
+    path at model_path/phylo_dist/. Raises Exception if neither exists.
+    """
+    config = AutoConfig.from_pretrained(model_path)
+
+    if not os.path.exists(config.phylo_dist_path):
+        fallback_path = os.path.join(model_path, "phylo_dist")
+        if os.path.exists(fallback_path):
+            config.phylo_dist_path = fallback_path
+        else:
+            raise Exception(
+                f"phylo_dist_path '{config.phylo_dist_path}' does not exist "
+                f"and fallback path '{fallback_path}' does not exist"
+            )
+
+    return AutoModelForMaskedLM.from_pretrained(model_path, config=config)
 
 
 AutoConfig.register("GPNStar", GPNStarConfig)


### PR DESCRIPTION
- Adds a new `load_model` function for GPN-Star that tries `model_path/phylo_dist` as falback `phylo_dist_path`. This simplified loading of models on HuggingFace.
- Modifies `logits.py` to use the new function (could be added to other places as well).