### PR TITLE
Add resumable GPN-Star inference

### DIFF
--- a/analysis/gpn-star/train_and_eval/workflow/Snakefile_ce11
+++ b/analysis/gpn-star/train_and_eval/workflow/Snakefile_ce11
@@ -19,7 +19,7 @@ from gpn.star.data import (
 )
 from gpn.star.data import make_windows, get_seq
 from gpn.star.data import GenomeMSA
-from gpn.star.utils import normalize_logits, get_entropy
+from gpn.star.utils import normalize_logits, get_entropy, get_llr
 import gzip
 from joblib import Parallel, delayed
 import numpy as np

--- a/analysis/gpn-star/train_and_eval/workflow/Snakefile_dm6
+++ b/analysis/gpn-star/train_and_eval/workflow/Snakefile_dm6
@@ -19,7 +19,7 @@ from gpn.star.data import (
 )
 from gpn.star.data import make_windows, get_seq
 from gpn.star.data import GenomeMSA
-from gpn.star.utils import normalize_logits, get_entropy
+from gpn.star.utils import normalize_logits, get_entropy, get_llr
 import gzip
 from joblib import Parallel, delayed
 import numpy as np

--- a/analysis/gpn-star/train_and_eval/workflow/Snakefile_gg6
+++ b/analysis/gpn-star/train_and_eval/workflow/Snakefile_gg6
@@ -19,7 +19,7 @@ from gpn.star.data import (
 )
 from gpn.star.data import make_windows, get_seq
 from gpn.star.data import GenomeMSA
-from gpn.star.utils import normalize_logits, get_entropy
+from gpn.star.utils import normalize_logits, get_entropy, get_llr
 import gzip
 from joblib import Parallel, delayed
 import numpy as np

--- a/analysis/gpn-star/train_and_eval/workflow/Snakefile_hg38
+++ b/analysis/gpn-star/train_and_eval/workflow/Snakefile_hg38
@@ -19,7 +19,7 @@ from gpn.star.data import (
 )
 from gpn.star.data import make_windows, get_seq
 from gpn.star.data import GenomeMSA
-from gpn.star.utils import normalize_logits, get_entropy
+from gpn.star.utils import normalize_logits, get_entropy, get_llr
 import gzip
 from joblib import Parallel, delayed
 import numpy as np

--- a/analysis/gpn-star/train_and_eval/workflow/Snakefile_mm39
+++ b/analysis/gpn-star/train_and_eval/workflow/Snakefile_mm39
@@ -19,7 +19,7 @@ from gpn.star.data import (
 )
 from gpn.star.data import make_windows, get_seq
 from gpn.star.data import GenomeMSA
-from gpn.star.utils import normalize_logits, get_entropy
+from gpn.star.utils import normalize_logits, get_entropy, get_llr
 import gzip
 from joblib import Parallel, delayed
 import numpy as np

--- a/analysis/gpn-star/train_and_eval/workflow/Snakefile_tair10
+++ b/analysis/gpn-star/train_and_eval/workflow/Snakefile_tair10
@@ -19,7 +19,7 @@ from gpn.star.data import (
 )
 from gpn.star.data import make_windows, get_seq
 from gpn.star.data import GenomeMSA
-from gpn.star.utils import normalize_logits, get_entropy
+from gpn.star.utils import normalize_logits, get_entropy, get_llr
 import gzip
 from joblib import Parallel, delayed
 import numpy as np

--- a/analysis/gpn-star/train_and_eval/workflow/rules/logits.smk
+++ b/analysis/gpn-star/train_and_eval/workflow/rules/logits.smk
@@ -54,6 +54,8 @@ rule get_logits:
         alignment="[A-Za-z0-9_]+",
         species="[A-Za-z0-9_-]+",
         window_size="\d+",
+    params:
+        checkpoint_batch_size=config.get("checkpoint_batch_size", 1_000_000),
     threads: workflow.cores
     shell:
         #$(echo $CUDA_VISIBLE_DEVICES | awk -F',' '{{print NF}}')
@@ -64,7 +66,9 @@ rule get_logits:
 
         torchrun --nproc_per_node=$num_gpus -m gpn.star.inference logits {input[0]} {input[1]} {wildcards.window_size} {input[2]} {output} \
         --per_device_batch_size 8 --is_file \
-        --dataloader_num_workers $dataloader_num_workers
+        --dataloader_num_workers $dataloader_num_workers \
+        --checkpoint_batch_size {params.checkpoint_batch_size} \
+        --cleanup_checkpoints
         """
 
 

--- a/analysis/gpn-star/train_and_eval/workflow/rules/vep.smk
+++ b/analysis/gpn-star/train_and_eval/workflow/rules/vep.smk
@@ -103,3 +103,48 @@ rule get_llr_calibrated:
         V = V.merge(df_calibration, on="pentanuc_mut", how="left")
         V["llr_calibrated"] = V["llr"] - V["llr_neutral_mean"]
         V[["llr_calibrated"]].to_parquet(output[0], index=False)
+
+
+rule get_absllr_calibrated:
+    input:
+        "results/logits/{dataset}/{genome}/{time_enc}/{clade_thres}/{alignment}/{species}/{window_size}/{model}.parquet",
+        "results/calibration/{genome}/{time_enc}/{clade_thres}/{alignment}/{species}/{window_size}/{model}/llr.parquet",
+        "results/genome/{genome}.fa.gz",
+    output:
+        "results/preds/absllr/{dataset}/{genome}/{time_enc}/{clade_thres}/{alignment}/{species}/{window_size}/{model}.parquet",
+    wildcard_constraints:
+        dataset="|".join(vep_datasets),
+        time_enc="[A-Za-z0-9_-]+",
+        clade_thres="[0-9.-]+",
+        alignment="[A-Za-z0-9_]+",
+        species="[A-Za-z0-9_-]+",
+        window_size="\d+",
+    run:
+        try:
+            V = load_dataset_from_file_or_dir(
+                wildcards.dataset,
+                split="test",
+                is_file=False,
+            )
+            V = V.to_pandas()
+        except:
+            V = Dataset.from_pandas(
+                pd.read_parquet(wildcards.dataset + "/test.parquet")
+            )
+        genome = Genome(input[2])
+        V["pentanuc"] = V.apply(
+            lambda row: genome.get_seq(
+                row["chrom"], row["pos"] - 3, row["pos"] + 2
+            ).upper(),
+            axis=1,
+        )
+        V["pentanuc_mut"] = V["pentanuc"] + "_" + V["alt"]
+        df_calibration = pd.read_parquet(input[1])
+        logits = pd.read_parquet(input[0])
+        normalized_logits = normalize_logits(logits)
+        V["llr"] = get_llr(normalized_logits, V["ref"], V["alt"])
+        V = V.merge(df_calibration, on="pentanuc_mut", how="left")
+        V["absllr_calibrated"] = np.abs(V["llr"]) - np.abs(
+            V["llr_neutral_mean"]
+        )
+        V[["absllr_calibrated"]].to_parquet(output[0], index=False)

--- a/gpn/star/checkpoint.py
+++ b/gpn/star/checkpoint.py
@@ -1,0 +1,757 @@
+"""Durable, resumable storage for batched inference predictions.
+
+This module deliberately does not know about models, datasets, or distributed
+execution. The inference runner is responsible for making the same batch
+decision on every process and for allowing only its main process to call the
+filesystem-mutating methods on :class:`CheckpointStore`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import tempfile
+from typing import Any, Mapping, Optional, Sequence, Tuple, Union
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+CHECKPOINT_FORMAT_VERSION = 1
+MANIFEST_FILENAME = "manifest.json"
+CHECKPOINT_METADATA_KEY = b"gpn.checkpoint"
+FINAL_METADATA_KEY = b"gpn.inference"
+
+
+def _default_file_mode() -> int:
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+    return 0o666 & ~current_umask
+
+
+DEFAULT_FILE_MODE = _default_file_mode()
+
+
+class CheckpointError(RuntimeError):
+    """Base class for checkpoint persistence errors."""
+
+
+class IncompatibleCheckpointError(CheckpointError):
+    """Raised when a checkpoint directory belongs to a different run."""
+
+
+class InvalidCheckpointError(CheckpointError):
+    """Raised when checkpoint contents are missing, corrupt, or inconsistent."""
+
+
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as error:
+        raise TypeError(
+            "Checkpoint run_signature must contain only JSON-compatible values"
+        ) from error
+
+
+def _normalized_json_value(value: Any) -> Any:
+    return json.loads(_canonical_json(value))
+
+
+def _sha256_json(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Best-effort directory sync after an atomic replacement."""
+
+    try:
+        descriptor = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        # Some filesystems do not support syncing directories.
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def _temporary_path(target: Path) -> Path:
+    descriptor, name = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    os.close(descriptor)
+    return Path(name)
+
+
+def _replacement_file_mode(target: Path) -> int:
+    try:
+        return stat.S_IMODE(target.stat().st_mode)
+    except FileNotFoundError:
+        return DEFAULT_FILE_MODE
+
+
+def _atomic_write_json(value: Mapping[str, Any], target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = _temporary_path(target)
+    try:
+        os.chmod(temporary, _replacement_file_mode(target))
+        with temporary.open("w", encoding="utf-8") as handle:
+            json.dump(
+                value,
+                handle,
+                allow_nan=False,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+        _fsync_directory(target.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_write_table(table: pa.Table, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = _temporary_path(target)
+    try:
+        os.chmod(temporary, _replacement_file_mode(target))
+        pq.write_table(table, temporary)
+        with temporary.open("rb") as handle:
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+        _fsync_directory(target.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def write_dataframe_atomic(
+    frame: pd.DataFrame,
+    output_path: Union[os.PathLike[str], str],
+) -> Path:
+    """Write a DataFrame atomically with normal creation permissions."""
+
+    if not isinstance(frame, pd.DataFrame):
+        raise TypeError("Output must be a pandas DataFrame")
+    try:
+        table = pa.Table.from_pandas(frame, preserve_index=False)
+    except (pa.ArrowException, TypeError, ValueError) as error:
+        raise InvalidCheckpointError(
+            f"Could not convert output to Arrow: {error}"
+        ) from error
+    output = Path(output_path)
+    _atomic_write_table(table, output)
+    return output
+
+
+def _schema_without_metadata(schema: pa.Schema) -> pa.Schema:
+    return schema.remove_metadata()
+
+
+def _schemas_equal(left: pa.Schema, right: pa.Schema) -> bool:
+    return _schema_without_metadata(left).equals(
+        _schema_without_metadata(right),
+        check_metadata=False,
+    )
+
+
+def _dict_differences(left: Any, right: Any, prefix: str = "") -> Sequence[str]:
+    if isinstance(left, dict) and isinstance(right, dict):
+        differences = []
+        for key in sorted(set(left) | set(right)):
+            path = f"{prefix}.{key}" if prefix else key
+            if key not in left:
+                differences.append(f"{path}: missing from existing manifest")
+            elif key not in right:
+                differences.append(f"{path}: unexpected in existing manifest")
+            else:
+                differences.extend(_dict_differences(left[key], right[key], path))
+        return differences
+    if left != right:
+        return [f"{prefix}: existing={left!r}, requested={right!r}"]
+    return []
+
+
+@dataclass(frozen=True)
+class BatchRange:
+    """A half-open row range assigned to one checkpoint file."""
+
+    index: int
+    start: int
+    stop: int
+
+    def __post_init__(self) -> None:
+        if not _is_int(self.index) or self.index < 0:
+            raise ValueError("Batch index must be a non-negative integer")
+        if not _is_int(self.start) or self.start < 0:
+            raise ValueError("Batch start must be a non-negative integer")
+        if not _is_int(self.stop) or self.stop <= self.start:
+            raise ValueError("Batch stop must be greater than batch start")
+
+    @property
+    def num_rows(self) -> int:
+        return self.stop - self.start
+
+    @property
+    def filename(self) -> str:
+        return f"batch_{self.index:08d}.parquet"
+
+
+def expected_batch_ranges(
+    total_rows: int,
+    batch_size: int,
+) -> Tuple[BatchRange, ...]:
+    """Return stable, ordered ranges without depending on process count."""
+
+    if not _is_int(total_rows) or total_rows <= 0:
+        raise ValueError("total_rows must be a positive integer")
+    if not _is_int(batch_size) or batch_size <= 0:
+        raise ValueError("batch_size must be a positive integer")
+
+    return tuple(
+        BatchRange(
+            index=index,
+            start=start,
+            stop=min(start + batch_size, total_rows),
+        )
+        for index, start in enumerate(range(0, total_rows, batch_size))
+    )
+
+
+@dataclass(frozen=True)
+class CheckpointManifest:
+    """Semantic identity and row partitioning for a checkpoint directory."""
+
+    run_signature: Mapping[str, Any]
+    total_rows: int
+    batch_size: int
+    format_version: int = CHECKPOINT_FORMAT_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.run_signature, Mapping):
+            raise TypeError("run_signature must be a mapping")
+        if not _is_int(self.total_rows) or self.total_rows <= 0:
+            raise ValueError("total_rows must be a positive integer")
+        if not _is_int(self.batch_size) or self.batch_size <= 0:
+            raise ValueError("batch_size must be a positive integer")
+        if not _is_int(self.format_version) or self.format_version <= 0:
+            raise ValueError("format_version must be a positive integer")
+        if self.format_version != CHECKPOINT_FORMAT_VERSION:
+            raise ValueError(f"format_version must be {CHECKPOINT_FORMAT_VERSION}")
+
+        normalized_signature = _normalized_json_value(dict(self.run_signature))
+        if not isinstance(normalized_signature, dict):
+            raise TypeError("run_signature must serialize to a JSON object")
+        object.__setattr__(self, "run_signature", normalized_signature)
+
+    @cached_property
+    def batches(self) -> Tuple[BatchRange, ...]:
+        return expected_batch_ranges(self.total_rows, self.batch_size)
+
+    @cached_property
+    def payload(self) -> Mapping[str, Any]:
+        return {
+            "batch_size": self.batch_size,
+            "format_version": self.format_version,
+            "num_batches": len(self.batches),
+            "run_signature": self.run_signature,
+            "total_rows": self.total_rows,
+        }
+
+    @cached_property
+    def digest(self) -> str:
+        return _sha256_json(self.payload)
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return {
+            **self.payload,
+            "manifest_digest": self.digest,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "CheckpointManifest":
+        if not isinstance(value, Mapping):
+            raise InvalidCheckpointError("Checkpoint manifest must be a JSON object")
+
+        required_keys = {
+            "batch_size",
+            "format_version",
+            "manifest_digest",
+            "num_batches",
+            "run_signature",
+            "total_rows",
+        }
+        if set(value) != required_keys:
+            missing = sorted(required_keys - set(value))
+            extra = sorted(set(value) - required_keys)
+            raise InvalidCheckpointError(
+                "Checkpoint manifest has invalid fields; "
+                f"missing={missing}, extra={extra}"
+            )
+
+        if value["format_version"] != CHECKPOINT_FORMAT_VERSION:
+            raise IncompatibleCheckpointError(
+                "Unsupported checkpoint format version "
+                f"{value['format_version']!r}; expected {CHECKPOINT_FORMAT_VERSION}"
+            )
+
+        try:
+            manifest = cls(
+                run_signature=value["run_signature"],
+                total_rows=value["total_rows"],
+                batch_size=value["batch_size"],
+                format_version=value["format_version"],
+            )
+        except (TypeError, ValueError) as error:
+            raise InvalidCheckpointError(
+                f"Checkpoint manifest contains invalid values: {error}"
+            ) from error
+
+        if value["num_batches"] != len(manifest.batches):
+            raise InvalidCheckpointError(
+                "Checkpoint manifest num_batches does not match its row partitioning"
+            )
+        if value["manifest_digest"] != manifest.digest:
+            raise InvalidCheckpointError("Checkpoint manifest digest is invalid")
+        return manifest
+
+    @classmethod
+    def read(
+        cls,
+        path: Union[os.PathLike[str], str],
+    ) -> "CheckpointManifest":
+        try:
+            with Path(path).open(encoding="utf-8") as handle:
+                value = json.load(handle)
+        except (OSError, json.JSONDecodeError) as error:
+            raise InvalidCheckpointError(
+                f"Could not read checkpoint manifest {path}: {error}"
+            ) from error
+        return cls.from_dict(value)
+
+    def assert_compatible(self, requested: "CheckpointManifest") -> None:
+        differences = _dict_differences(self.payload, requested.payload)
+        if differences:
+            detail = "\n".join(f"- {difference}" for difference in differences[:20])
+            if len(differences) > 20:
+                detail += f"\n- ... and {len(differences) - 20} more differences"
+            raise IncompatibleCheckpointError(
+                "Checkpoint manifest is incompatible with this inference run:\n"
+                f"{detail}"
+            )
+
+
+class CheckpointStore:
+    """Manage one manifest and its atomically committed Parquet batches."""
+
+    def __init__(
+        self,
+        directory: Union[os.PathLike[str], str],
+        manifest: CheckpointManifest,
+    ) -> None:
+        self.directory = Path(directory)
+        self.manifest = manifest
+        self._known_schema: Optional[pa.Schema] = None
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.directory / MANIFEST_FILENAME
+
+    @property
+    def batches(self) -> Tuple[BatchRange, ...]:
+        return self.manifest.batches
+
+    def batch_path(self, batch: BatchRange | int) -> Path:
+        return self.directory / self._expected_batch(batch).filename
+
+    def initialize(self) -> None:
+        """Create a new manifest or validate an existing one exactly."""
+
+        if self.directory.exists() and not self.directory.is_dir():
+            raise InvalidCheckpointError(
+                f"Checkpoint path is not a directory: {self.directory}"
+            )
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+        if self.manifest_path.exists():
+            existing = CheckpointManifest.read(self.manifest_path)
+            existing.assert_compatible(self.manifest)
+            return
+
+        contents = list(self.directory.iterdir())
+        if contents:
+            raise IncompatibleCheckpointError(
+                "Refusing to reuse a non-empty checkpoint directory without "
+                f"{MANIFEST_FILENAME}: {self.directory}"
+            )
+        _atomic_write_json(self.manifest.to_dict(), self.manifest_path)
+
+    def completed_batch_indices(self) -> Tuple[int, ...]:
+        """Validate present batches and return their indices in row order."""
+
+        self._require_compatible_manifest()
+        expected_names = {batch.filename for batch in self.batches}
+        unexpected = sorted(
+            path.name
+            for path in self.directory.glob("batch_*.parquet")
+            if path.name not in expected_names
+        )
+        if unexpected:
+            raise InvalidCheckpointError(
+                f"Unexpected checkpoint batch files: {unexpected}"
+            )
+
+        completed = []
+        expected_schema = None
+        for batch in self.batches:
+            schema = self.validate_batch(batch)
+            if schema is None:
+                continue
+            if expected_schema is not None and not _schemas_equal(
+                schema, expected_schema
+            ):
+                raise InvalidCheckpointError(
+                    f"Checkpoint batch {batch.index} has a different schema"
+                )
+            expected_schema = schema
+            completed.append(batch.index)
+        self._known_schema = expected_schema
+        return tuple(completed)
+
+    def validate_batch(
+        self,
+        batch: BatchRange | int,
+        expected_schema: Optional[pa.Schema] = None,
+    ) -> Optional[pa.Schema]:
+        """Return a committed batch's data schema, or ``None`` if absent."""
+
+        expected_batch = self._expected_batch(batch)
+        path = self.directory / expected_batch.filename
+        if not path.exists():
+            return None
+        if not path.is_file():
+            raise InvalidCheckpointError(f"Checkpoint batch is not a file: {path}")
+
+        try:
+            parquet_file = pq.ParquetFile(path)
+            schema = parquet_file.schema_arrow
+            row_count = parquet_file.metadata.num_rows
+        except (OSError, pa.ArrowException) as error:
+            raise InvalidCheckpointError(
+                f"Could not read checkpoint batch {path}: {error}"
+            ) from error
+
+        if row_count != expected_batch.num_rows:
+            raise InvalidCheckpointError(
+                f"Checkpoint batch {expected_batch.index} has {row_count} rows; "
+                f"expected {expected_batch.num_rows}"
+            )
+
+        metadata = schema.metadata or {}
+        raw_metadata = metadata.get(CHECKPOINT_METADATA_KEY)
+        if raw_metadata is None:
+            raise InvalidCheckpointError(
+                f"Checkpoint batch {expected_batch.index} lacks GPN metadata"
+            )
+        try:
+            checkpoint_metadata = json.loads(raw_metadata.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise InvalidCheckpointError(
+                f"Checkpoint batch {expected_batch.index} has invalid GPN metadata"
+            ) from error
+
+        expected_metadata = self._batch_metadata(expected_batch)
+        if checkpoint_metadata != expected_metadata:
+            differences = _dict_differences(checkpoint_metadata, expected_metadata)
+            detail = "; ".join(differences)
+            raise InvalidCheckpointError(
+                f"Checkpoint batch {expected_batch.index} metadata is incompatible: "
+                f"{detail}"
+            )
+
+        data_schema = _schema_without_metadata(schema)
+        if expected_schema is not None and not _schemas_equal(
+            data_schema, expected_schema
+        ):
+            raise InvalidCheckpointError(
+                f"Checkpoint batch {expected_batch.index} has a different schema"
+            )
+        return data_schema
+
+    def write_batch(
+        self,
+        batch: BatchRange | int,
+        frame: pd.DataFrame,
+    ) -> Path:
+        """Atomically commit one prediction frame for its expected row range."""
+
+        self._require_compatible_manifest()
+        expected_batch = self._expected_batch(batch)
+        path = self.directory / expected_batch.filename
+        if path.exists():
+            self.validate_batch(expected_batch)
+            raise FileExistsError(f"Checkpoint batch is already committed: {path}")
+        if not isinstance(frame, pd.DataFrame):
+            raise TypeError("Checkpoint predictions must be a pandas DataFrame")
+        if len(frame) != expected_batch.num_rows:
+            raise ValueError(
+                f"Prediction frame has {len(frame)} rows; "
+                f"batch {expected_batch.index} expects {expected_batch.num_rows}"
+            )
+
+        try:
+            table = pa.Table.from_pandas(frame, preserve_index=False)
+        except (pa.ArrowException, TypeError, ValueError) as error:
+            raise InvalidCheckpointError(
+                f"Could not convert batch {expected_batch.index} to Arrow: {error}"
+            ) from error
+
+        completed_schema = self._known_or_first_committed_schema(
+            excluding=expected_batch
+        )
+        if completed_schema is not None and not _schemas_equal(
+            table.schema, completed_schema
+        ):
+            raise InvalidCheckpointError(
+                f"Prediction frame for batch {expected_batch.index} has a "
+                "different schema from existing checkpoints"
+            )
+
+        metadata = dict(table.schema.metadata or {})
+        metadata[CHECKPOINT_METADATA_KEY] = _canonical_json(
+            self._batch_metadata(expected_batch)
+        ).encode("utf-8")
+        table = table.replace_schema_metadata(metadata)
+        _atomic_write_table(table, path)
+        committed_schema = self.validate_batch(expected_batch)
+        if self._known_schema is None:
+            self._known_schema = committed_schema
+        return path
+
+    def combine_to(self, output_path: Union[os.PathLike[str], str]) -> Path:
+        """Stream all batches in numeric order into one atomic final output."""
+
+        self._require_compatible_manifest()
+        output = Path(output_path)
+        self._validate_output_location(output)
+
+        schema = self._validate_complete_set()
+        final_metadata = {
+            FINAL_METADATA_KEY: _canonical_json(
+                {
+                    "manifest_digest": self.manifest.digest,
+                    "total_rows": self.manifest.total_rows,
+                }
+            ).encode("utf-8")
+        }
+        final_schema = schema.with_metadata(final_metadata)
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        temporary = _temporary_path(output)
+        try:
+            os.chmod(temporary, _replacement_file_mode(output))
+            with pq.ParquetWriter(temporary, final_schema) as writer:
+                for batch in self.batches:
+                    try:
+                        table = pq.read_table(self.batch_path(batch))
+                    except (OSError, pa.ArrowException) as error:
+                        raise InvalidCheckpointError(
+                            f"Could not read checkpoint batch {batch.index}: {error}"
+                        ) from error
+                    if not _schemas_equal(table.schema, schema):
+                        raise InvalidCheckpointError(
+                            f"Checkpoint batch {batch.index} has a different schema"
+                        )
+                    writer.write_table(table.replace_schema_metadata(final_metadata))
+
+            with temporary.open("rb") as handle:
+                os.fsync(handle.fileno())
+            self._validate_final_file(temporary, schema)
+            os.replace(temporary, output)
+            _fsync_directory(output.parent)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+        self.validate_final(output)
+        return output
+
+    def validate_final(
+        self,
+        output_path: Union[os.PathLike[str], str],
+    ) -> pa.Schema:
+        """Validate that a final file was assembled from this exact manifest."""
+
+        self._require_compatible_manifest()
+        schema = self._validate_complete_set()
+        output = Path(output_path)
+        if not output.is_file():
+            raise InvalidCheckpointError(f"Final output does not exist: {output}")
+        self._validate_final_file(output, schema)
+        return schema
+
+    def cleanup(
+        self,
+        final_output_path: Union[os.PathLike[str], str],
+    ) -> bool:
+        """Remove only managed files after validating the committed final output.
+
+        Returns ``True`` when the checkpoint directory was removed. Unknown
+        files are preserved; in that case the compatible manifest is also kept
+        and this method returns ``False``.
+        """
+
+        self.validate_final(final_output_path)
+
+        known_batch_paths = {self.batch_path(batch) for batch in self.batches}
+        known_paths = known_batch_paths | {self.manifest_path}
+        unknown_paths = [
+            path for path in self.directory.iterdir() if path not in known_paths
+        ]
+
+        for path in known_batch_paths:
+            path.unlink(missing_ok=True)
+
+        if unknown_paths:
+            return False
+
+        self.manifest_path.unlink(missing_ok=True)
+        try:
+            self.directory.rmdir()
+        except OSError:
+            return False
+        return True
+
+    def _expected_batch(self, batch: BatchRange | int) -> BatchRange:
+        if isinstance(batch, bool):
+            raise TypeError("Batch must be a BatchRange or integer index")
+        if isinstance(batch, int):
+            if batch < 0:
+                raise IndexError(f"Batch index out of range: {batch}")
+            try:
+                return self.batches[batch]
+            except IndexError as error:
+                raise IndexError(f"Batch index out of range: {batch}") from error
+        if not isinstance(batch, BatchRange):
+            raise TypeError("Batch must be a BatchRange or integer index")
+        try:
+            expected = self.batches[batch.index]
+        except IndexError as error:
+            raise IndexError(f"Batch index out of range: {batch.index}") from error
+        if batch != expected:
+            raise ValueError(
+                f"Batch range {batch} does not match expected range {expected}"
+            )
+        return expected
+
+    def _batch_metadata(self, batch: BatchRange) -> Mapping[str, Any]:
+        return {
+            "batch_index": batch.index,
+            "manifest_digest": self.manifest.digest,
+            "start": batch.start,
+            "stop": batch.stop,
+        }
+
+    def _known_or_first_committed_schema(
+        self,
+        excluding: BatchRange,
+    ) -> Optional[pa.Schema]:
+        if self._known_schema is not None:
+            return self._known_schema
+        for batch in self.batches:
+            if batch == excluding or not self.batch_path(batch).exists():
+                continue
+            self._known_schema = self.validate_batch(batch)
+            return self._known_schema
+        return None
+
+    def _require_compatible_manifest(self) -> None:
+        if not self.manifest_path.is_file():
+            raise InvalidCheckpointError(
+                f"Checkpoint manifest does not exist: {self.manifest_path}"
+            )
+        existing = CheckpointManifest.read(self.manifest_path)
+        existing.assert_compatible(self.manifest)
+
+    def _validate_complete_set(self) -> pa.Schema:
+        completed = self.completed_batch_indices()
+        expected = tuple(batch.index for batch in self.batches)
+        if completed != expected:
+            missing = sorted(set(expected) - set(completed))
+            raise InvalidCheckpointError(
+                f"Cannot assemble final output; missing checkpoint batches: {missing}"
+            )
+
+        schema = self.validate_batch(self.batches[0])
+        if schema is None:
+            raise InvalidCheckpointError("No checkpoint schema is available")
+        for batch in self.batches[1:]:
+            self.validate_batch(batch, expected_schema=schema)
+        return schema
+
+    def _validate_final_file(self, path: Path, expected_schema: pa.Schema) -> None:
+        try:
+            parquet_file = pq.ParquetFile(path)
+            schema = parquet_file.schema_arrow
+            row_count = parquet_file.metadata.num_rows
+        except (OSError, pa.ArrowException) as error:
+            raise InvalidCheckpointError(
+                f"Could not read final output {path}: {error}"
+            ) from error
+
+        if row_count != self.manifest.total_rows:
+            raise InvalidCheckpointError(
+                f"Final output has {row_count} rows; "
+                f"expected {self.manifest.total_rows}"
+            )
+        if not _schemas_equal(schema, expected_schema):
+            raise InvalidCheckpointError("Final output has an incompatible schema")
+
+        metadata = schema.metadata or {}
+        raw_metadata = metadata.get(FINAL_METADATA_KEY)
+        if raw_metadata is None:
+            raise InvalidCheckpointError("Final output lacks GPN provenance metadata")
+        try:
+            final_metadata = json.loads(raw_metadata.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise InvalidCheckpointError(
+                "Final output has invalid GPN provenance metadata"
+            ) from error
+        expected_metadata = {
+            "manifest_digest": self.manifest.digest,
+            "total_rows": self.manifest.total_rows,
+        }
+        if final_metadata != expected_metadata:
+            raise InvalidCheckpointError(
+                "Final output belongs to a different checkpoint manifest"
+            )
+
+    def _validate_output_location(self, output: Path) -> None:
+        checkpoint_directory = self.directory.resolve()
+        resolved_output = output.resolve()
+        if resolved_output == checkpoint_directory or checkpoint_directory in (
+            resolved_output,
+            *resolved_output.parents,
+        ):
+            raise ValueError("Final output must be outside the checkpoint directory")

--- a/gpn/star/inference.py
+++ b/gpn/star/inference.py
@@ -1,10 +1,22 @@
 import argparse
-from datasets import load_dataset, disable_caching, Dataset
+import hashlib
+import importlib.metadata
+import json
 import os
+from pathlib import Path
 import tempfile
-from transformers import Trainer, TrainingArguments
-import pandas as pd
 
+from accelerate.utils import broadcast_object_list
+from datasets import disable_caching, Dataset
+import pandas as pd
+from transformers import Trainer, TrainingArguments
+
+from gpn.star.checkpoint import (
+    CheckpointError,
+    CheckpointManifest,
+    CheckpointStore,
+    write_dataframe_atomic,
+)
 from gpn.star.data import load_dataset_from_file_or_dir
 from gpn.star.data import GenomeMSA
 from gpn.star.vep import VEPInference
@@ -24,28 +36,488 @@ class_mapping = {
 }
 
 
+def _validate_runtime_options(
+    dataset,
+    per_device_batch_size,
+    dataloader_num_workers,
+    checkpoint_batch_size=None,
+):
+    if len(dataset) == 0:
+        raise ValueError("Inference dataset must contain at least one row")
+    if per_device_batch_size <= 0:
+        raise ValueError("per_device_batch_size must be positive")
+    if dataloader_num_workers < 0:
+        raise ValueError("dataloader_num_workers must be non-negative")
+    if checkpoint_batch_size is not None and checkpoint_batch_size <= 0:
+        raise ValueError("checkpoint_batch_size must be positive")
+
+
+def _create_trainer(
+    inference,
+    per_device_batch_size,
+    dataloader_num_workers,
+):
+    temporary_output_dir = tempfile.TemporaryDirectory(prefix="gpn-star-inference-")
+    training_args = TrainingArguments(
+        output_dir=temporary_output_dir.name,
+        per_device_eval_batch_size=per_device_batch_size,
+        dataloader_num_workers=dataloader_num_workers,
+        remove_unused_columns=False,
+        torch_compile=True,
+        fp16=True,
+        report_to="none",
+    )
+    trainer = Trainer(model=inference.model, args=training_args)
+    # Keep the directory alive for as long as Trainer may use it.
+    trainer._gpn_temporary_output_dir = temporary_output_dir
+    return trainer
+
+
+def _is_main_process(trainer):
+    return trainer.accelerator.is_main_process
+
+
+def _predict_with_trainer(dataset, inference, trainer):
+    if _is_main_process(trainer):
+        print(dataset)
+    predictions = trainer.predict(test_dataset=dataset).predictions
+    if not _is_main_process(trainer):
+        return None
+    return inference.postprocess(predictions)
+
+
 def run_inference(
     dataset,
     inference,
     per_device_batch_size=8,
     dataloader_num_workers=0,
 ):
-    dataset.set_transform(inference.tokenize_function)
-    training_args = TrainingArguments(
-        output_dir=tempfile.TemporaryDirectory().name,
-        per_device_eval_batch_size=per_device_batch_size,
-        dataloader_num_workers=dataloader_num_workers,
-        remove_unused_columns=False,
-        torch_compile=True,
-        fp16=True,
+    """Run one inference pass and return predictions on the main process."""
+
+    _validate_runtime_options(
+        dataset,
+        per_device_batch_size,
+        dataloader_num_workers,
     )
-    print(dataset)
-    trainer = Trainer(model=inference.model, args=training_args)
-    pred = trainer.predict(test_dataset=dataset).predictions
-    return inference.postprocess(pred)
+    dataset.set_transform(inference.tokenize_function)
+    trainer = _create_trainer(
+        inference,
+        per_device_batch_size,
+        dataloader_num_workers,
+    )
+    return _predict_with_trainer(dataset, inference, trainer)
 
 
-if __name__ == "__main__":
+def _call_on_main_process(trainer, operation, description):
+    """Run a filesystem operation on rank zero and share its result or error."""
+
+    is_main_process = _is_main_process(trainer)
+    num_processes = trainer.accelerator.num_processes
+    if num_processes == 1:
+        if not is_main_process:
+            raise RuntimeError("Single-process Trainer did not select a main process")
+        return operation()
+
+    original_error = None
+    payload = None
+    if is_main_process:
+        try:
+            payload = {
+                "ok": True,
+                "value": operation(),
+            }
+        except BaseException as error:
+            original_error = error
+            payload = {
+                "ok": False,
+                "error_type": type(error).__name__,
+                "error": str(error),
+            }
+
+    shared_payload = [payload]
+    broadcast_object_list(shared_payload, from_process=0)
+    payload = shared_payload[0]
+    if not payload["ok"]:
+        if original_error is not None:
+            raise original_error
+        raise CheckpointError(
+            f"{description} failed on the main process: "
+            f"{payload['error_type']}: {payload['error']}"
+        )
+    return payload["value"]
+
+
+def run_inference_with_checkpoints(
+    dataset,
+    inference,
+    output_path,
+    checkpoint_dir,
+    checkpoint_batch_size,
+    run_signature,
+    per_device_batch_size=8,
+    dataloader_num_workers=0,
+    cleanup_checkpoints=False,
+):
+    """Run resumable inference and atomically assemble the final Parquet file.
+
+    Checkpoint row ranges do not depend on process count, so an interrupted run
+    can resume with a different number of GPUs. Only the Trainer main process
+    reads or writes checkpoint files. Inputs are assumed to be immutable while
+    a checkpoint directory is in use. The automatic Zarr identity validates
+    metadata and array directories, but not in-place chunk rewrites; after such
+    a rewrite, use a new ``checkpoint_revision`` or checkpoint directory.
+    """
+
+    _validate_runtime_options(
+        dataset,
+        per_device_batch_size,
+        dataloader_num_workers,
+        checkpoint_batch_size=checkpoint_batch_size,
+    )
+    manifest = CheckpointManifest(
+        run_signature=run_signature,
+        total_rows=len(dataset),
+        batch_size=checkpoint_batch_size,
+    )
+    store = CheckpointStore(checkpoint_dir, manifest)
+
+    dataset.set_transform(inference.tokenize_function)
+    # Trainer/Accelerate must initialize distributed state before rank checks.
+    trainer = _create_trainer(
+        inference,
+        per_device_batch_size,
+        dataloader_num_workers,
+    )
+
+    def prepare_checkpoints():
+        store.initialize()
+        return store.completed_batch_indices()
+
+    completed = set(
+        _call_on_main_process(
+            trainer,
+            prepare_checkpoints,
+            "Checkpoint initialization",
+        )
+    )
+    if completed and _is_main_process(trainer):
+        print(
+            f"Resuming from {len(completed)} of {len(store.batches)} "
+            f"completed checkpoint batches in {checkpoint_dir}"
+        )
+
+    for batch in store.batches:
+        if batch.index in completed:
+            if _is_main_process(trainer):
+                print(f"Skipping completed checkpoint batch {batch.index}")
+            continue
+
+        if _is_main_process(trainer):
+            print(
+                f"Processing checkpoint batch {batch.index}: "
+                f"rows {batch.start}:{batch.stop}"
+            )
+        batch_dataset = dataset.select(range(batch.start, batch.stop))
+        predictions = trainer.predict(test_dataset=batch_dataset).predictions
+
+        def commit_batch():
+            prediction_frame = inference.postprocess(predictions)
+            store.write_batch(batch, prediction_frame)
+
+        _call_on_main_process(
+            trainer,
+            commit_batch,
+            f"Writing checkpoint batch {batch.index}",
+        )
+
+    def finalize_output():
+        store.combine_to(output_path)
+        removed_checkpoint_dir = None
+        if cleanup_checkpoints:
+            removed_checkpoint_dir = store.cleanup(output_path)
+        return removed_checkpoint_dir
+
+    removed_checkpoint_dir = _call_on_main_process(
+        trainer,
+        finalize_output,
+        "Final output assembly",
+    )
+    if _is_main_process(trainer):
+        print(f"Wrote predictions to {output_path}")
+        if cleanup_checkpoints:
+            if removed_checkpoint_dir:
+                print(f"Cleaned up checkpoint directory: {checkpoint_dir}")
+            else:
+                print(
+                    "Removed managed checkpoint files but preserved the "
+                    f"non-empty checkpoint directory: {checkpoint_dir}"
+                )
+        return Path(output_path)
+    return None
+
+
+def _resource_identity(value):
+    """Return a JSON identity for a local resource or remote identifier."""
+
+    value = str(value)
+    path = Path(value)
+    try:
+        exists = path.exists()
+    except OSError:
+        exists = False
+    if not exists:
+        return {"identifier": value}
+
+    resolved = path.resolve()
+    stat = resolved.stat()
+    identity = {
+        "path": str(resolved),
+        "kind": "directory" if resolved.is_dir() else "file",
+        "ctime_ns": stat.st_ctime_ns,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+    if resolved.is_file():
+        identity["size"] = stat.st_size
+        if stat.st_size <= 16 * 1024 * 1024:
+            identity["sha256"] = _file_digest(resolved)
+    else:
+        identity["tree"] = _directory_tree_identity(resolved)
+    return identity
+
+
+def _file_digest(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _should_hash_directory_file(path):
+    return path.name in {
+        ".zarray",
+        ".zattrs",
+        ".zgroup",
+        ".zmetadata",
+    } or path.suffix.lower() in {".json", ".yaml", ".yml"}
+
+
+def _directory_tree_identity(root):
+    """Fingerprint file metadata and small control-file contents below root.
+
+    Reading every byte of a model checkpoint or Zarr MSA would make startup
+    impractical. Size, mtime, and ctime cover ordinary data replacement, while
+    model/Zarr metadata files are content-hashed as well.
+    """
+
+    if (root / ".zgroup").is_file():
+        return _zarr_tree_identity(root)
+
+    digest = hashlib.sha256()
+    file_count = 0
+    total_size = 0
+    for directory, directory_names, file_names in os.walk(root):
+        directory_names.sort()
+        file_names.sort()
+        directory_path = Path(directory)
+        for file_name in file_names:
+            path = directory_path / file_name
+            relative_path = path.relative_to(root).as_posix()
+            stat = path.lstat()
+            entry = {
+                "path": relative_path,
+                "size": stat.st_size,
+                "mtime_ns": stat.st_mtime_ns,
+                "ctime_ns": stat.st_ctime_ns,
+            }
+            if path.is_symlink():
+                entry["symlink"] = os.readlink(path)
+            elif path.is_file() and _should_hash_directory_file(path):
+                entry["sha256"] = _file_digest(path)
+            digest.update(
+                json.dumps(
+                    entry,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ).encode("utf-8")
+            )
+            digest.update(b"\n")
+            file_count += 1
+            total_size += stat.st_size
+    return {
+        "strategy": "recursive-file-metadata-v1",
+        "file_count": file_count,
+        "total_size": total_size,
+        "metadata_sha256": digest.hexdigest(),
+    }
+
+
+def _zarr_tree_identity(root):
+    """Fingerprint Zarr metadata without traversing millions of chunk files."""
+
+    digest = hashlib.sha256()
+    array_count = 0
+    metadata_file_count = 0
+    metadata_size = 0
+    for path in sorted(root.iterdir(), key=lambda item: item.name):
+        stat = path.lstat()
+        entry = {
+            "path": path.name,
+            "kind": "directory" if path.is_dir() else "file",
+            "size": stat.st_size,
+            "mtime_ns": stat.st_mtime_ns,
+            "ctime_ns": stat.st_ctime_ns,
+        }
+        if path.is_symlink():
+            entry["symlink"] = os.readlink(path)
+        elif path.is_file() and _should_hash_directory_file(path):
+            entry["sha256"] = _file_digest(path)
+            metadata_file_count += 1
+            metadata_size += stat.st_size
+        elif path.is_dir():
+            array_count += 1
+            for metadata_name in [".zarray", ".zattrs", ".zgroup"]:
+                metadata_path = path / metadata_name
+                if not metadata_path.is_file():
+                    continue
+                metadata_stat = metadata_path.stat()
+                entry[metadata_name] = {
+                    "size": metadata_stat.st_size,
+                    "mtime_ns": metadata_stat.st_mtime_ns,
+                    "ctime_ns": metadata_stat.st_ctime_ns,
+                    "sha256": _file_digest(metadata_path),
+                }
+                metadata_file_count += 1
+                metadata_size += metadata_stat.st_size
+        digest.update(
+            json.dumps(
+                entry,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        )
+        digest.update(b"\n")
+    return {
+        "strategy": "zarr-metadata-and-array-directories-v1",
+        "array_count": array_count,
+        "metadata_file_count": metadata_file_count,
+        "metadata_size": metadata_size,
+        "metadata_sha256": digest.hexdigest(),
+    }
+
+
+def _source_revision():
+    """Hash the checked-out GPN Python sources that can affect inference."""
+
+    package_root = Path(__file__).resolve().parents[1]
+    digest = hashlib.sha256()
+    source_files = sorted(package_root.rglob("*.py"))
+    for path in source_files:
+        digest.update(path.relative_to(package_root).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+    return {
+        "file_count": len(source_files),
+        "sha256": digest.hexdigest(),
+    }
+
+
+def _dependency_versions():
+    versions = {}
+    for distribution in [
+        "accelerate",
+        "datasets",
+        "numpy",
+        "pandas",
+        "pyarrow",
+        "torch",
+        "transformers",
+    ]:
+        try:
+            versions[distribution] = importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            versions[distribution] = None
+    return versions
+
+
+def _model_config_signature(inference):
+    wrapped_model = getattr(inference.model, "model", None)
+    config = getattr(wrapped_model, "config", None)
+    if config is None:
+        return None
+
+    config_payload = config.to_dict()
+    serialized = json.dumps(
+        config_payload,
+        default=str,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return {
+        "sha256": hashlib.sha256(serialized.encode("utf-8")).hexdigest(),
+        "commit_hash": getattr(config, "_commit_hash", None),
+    }
+
+
+def build_run_signature(args, dataset, msa_paths, inference):
+    """Describe every semantic input that can affect checkpoint predictions."""
+
+    wrapped_model = getattr(inference.model, "model", None)
+    config = getattr(wrapped_model, "config", None)
+    resolved_phylo_dist_path = getattr(config, "phylo_dist_path", None)
+    return {
+        "checkpoint_revision": getattr(args, "checkpoint_revision", None),
+        "command": args.command,
+        "dataset": {
+            "columns": list(dataset.column_names),
+            "fingerprint": getattr(dataset, "_fingerprint", None),
+            "input": _resource_identity(args.input_path),
+            "is_file": args.is_file,
+            "split": args.split,
+        },
+        "inference": {
+            "center_window_size": args.center_window_size,
+            "disable_aux_features": args.disable_aux_features,
+            "implementation": (
+                f"{type(inference).__module__}.{type(inference).__qualname__}"
+            ),
+            "window_size": args.window_size,
+        },
+        "model": {
+            "config": _model_config_signature(inference),
+            "resource": _resource_identity(args.model_path),
+        },
+        "msa": [
+            {
+                "order": order,
+                "n_species": str(n_species),
+                "resource": _resource_identity(path),
+            }
+            for order, (n_species, path) in enumerate(msa_paths.items())
+        ],
+        "phylo_dist": (
+            _resource_identity(resolved_phylo_dist_path)
+            if resolved_phylo_dist_path is not None
+            else None
+        ),
+        "software": {
+            "dependencies": _dependency_versions(),
+            "gpn_source": _source_revision(),
+        },
+    }
+
+
+def _write_parquet_atomic(frame, output_path):
+    return write_dataframe_atomic(frame, output_path)
+
+
+def _build_parser():
     parser = argparse.ArgumentParser(
         description="Run inference with AutoModelForMaskedLM",
     )
@@ -83,7 +555,10 @@ if __name__ == "__main__":
         default=8,
     )
     parser.add_argument(
-        "--dataloader_num_workers", type=int, default=0, help="Dataloader num workers"
+        "--dataloader_num_workers",
+        type=int,
+        default=0,
+        help="Dataloader num workers",
     )
     parser.add_argument(
         "--split",
@@ -94,7 +569,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--is_file",
         action="store_true",
-        help="VARIANTS_PATH is a file, not directory",
+        help="INPUT_PATH is a file, not a directory or Hub dataset",
     )
     parser.add_argument(
         "--disable_aux_features",
@@ -105,7 +580,74 @@ if __name__ == "__main__":
         type=int,
         help="[embedding] Genomic window size to average at the center of the windows",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--checkpoint_batch_size",
+        type=int,
+        default=None,
+        help=(
+            "Rows per durable checkpoint batch. Enables resumable inference "
+            "when set."
+        ),
+    )
+    parser.add_argument(
+        "--checkpoint_dir",
+        type=str,
+        default=None,
+        help=("Checkpoint directory. Defaults to OUTPUT_PATH + '_checkpoints'."),
+    )
+    parser.add_argument(
+        "--checkpoint_revision",
+        type=str,
+        default=None,
+        help=(
+            "Optional immutable data/model revision identifier included in "
+            "resume checks. Zarr chunk contents are assumed immutable; use a "
+            "new value after any in-place MSA chunk rewrite, which automatic "
+            "metadata checks cannot detect."
+        ),
+    )
+    parser.add_argument(
+        "--cleanup_checkpoints",
+        action="store_true",
+        help="Remove managed checkpoints after the final output is committed",
+    )
+    parser.add_argument(
+        "--phylo_dist_path",
+        type=str,
+        default=None,
+        help=(
+            "[logits] Override the phylogenetic-distance directory stored in "
+            "the model config"
+        ),
+    )
+    return parser
+
+
+def _validate_cli_args(parser, args):
+    if args.window_size <= 0:
+        parser.error("window_size must be positive")
+    if args.per_device_batch_size <= 0:
+        parser.error("--per_device_batch_size must be positive")
+    if args.dataloader_num_workers < 0:
+        parser.error("--dataloader_num_workers must be non-negative")
+    if args.checkpoint_batch_size is not None and args.checkpoint_batch_size <= 0:
+        parser.error("--checkpoint_batch_size must be positive")
+    if args.checkpoint_dir is not None and args.checkpoint_batch_size is None:
+        parser.error("--checkpoint_dir requires --checkpoint_batch_size")
+    if args.checkpoint_revision is not None and args.checkpoint_batch_size is None:
+        parser.error("--checkpoint_revision requires --checkpoint_batch_size")
+    if args.cleanup_checkpoints and args.checkpoint_batch_size is None:
+        parser.error("--cleanup_checkpoints requires --checkpoint_batch_size")
+    if args.phylo_dist_path is not None and args.command != "logits":
+        parser.error("--phylo_dist_path is only supported by the logits command")
+    if args.center_window_size is not None and args.center_window_size <= 0:
+        parser.error("--center_window_size must be positive")
+
+
+def main(argv=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    _validate_cli_args(parser, args)
     print(args)
 
     try:
@@ -114,10 +656,17 @@ if __name__ == "__main__":
             split=args.split,
             is_file=args.is_file,
         )
-    except:
+    except Exception:
         dataset = Dataset.from_pandas(
-            pd.read_parquet(args.input_path + "/test.parquet")
+            pd.read_parquet(os.path.join(args.input_path, "test.parquet"))
         )
+
+    _validate_runtime_options(
+        dataset,
+        args.per_device_batch_size,
+        args.dataloader_num_workers,
+        checkpoint_batch_size=args.checkpoint_batch_size,
+    )
 
     msa_paths = find_directory_sum_paths(args.msa_path)
     genome_msa_list = [
@@ -130,12 +679,13 @@ if __name__ == "__main__":
         for n_species, path in msa_paths.items()
     ]
 
-    # sorry this is hacky, should use subparsers
-    kwargs = (
-        dict(center_window_size=args.center_window_size)
-        if args.command == "embedding"
-        else {}
-    )
+    # This predates subparsers; keep command-specific kwargs explicit.
+    kwargs = {}
+    if args.command == "embedding" and args.center_window_size is not None:
+        kwargs["center_window_size"] = args.center_window_size
+    if args.command == "logits" and args.phylo_dist_path is not None:
+        kwargs["phylo_dist_path"] = args.phylo_dist_path
+
     inference = class_mapping[args.command](
         args.model_path,
         genome_msa_list,
@@ -143,13 +693,37 @@ if __name__ == "__main__":
         disable_aux_features=args.disable_aux_features,
         **kwargs,
     )
-    pred = run_inference(
-        dataset,
-        inference,
-        per_device_batch_size=args.per_device_batch_size,
-        dataloader_num_workers=args.dataloader_num_workers,
-    )
-    directory = os.path.dirname(args.output_path)
-    if directory != "" and not os.path.exists(directory):
-        os.makedirs(directory)
-    pred.to_parquet(args.output_path, index=False)
+
+    if args.checkpoint_batch_size is not None:
+        checkpoint_dir = args.checkpoint_dir or (args.output_path + "_checkpoints")
+        run_signature = build_run_signature(
+            args,
+            dataset,
+            msa_paths,
+            inference,
+        )
+        run_inference_with_checkpoints(
+            dataset,
+            inference,
+            output_path=args.output_path,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_batch_size=args.checkpoint_batch_size,
+            run_signature=run_signature,
+            per_device_batch_size=args.per_device_batch_size,
+            dataloader_num_workers=args.dataloader_num_workers,
+            cleanup_checkpoints=args.cleanup_checkpoints,
+        )
+    else:
+        predictions = run_inference(
+            dataset,
+            inference,
+            per_device_batch_size=args.per_device_batch_size,
+            dataloader_num_workers=args.dataloader_num_workers,
+        )
+        if predictions is not None:
+            _write_parquet_atomic(predictions, args.output_path)
+            print(f"Wrote predictions to {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gpn/star/logits.py
+++ b/gpn/star/logits.py
@@ -8,9 +8,9 @@ from gpn.data import Tokenizer
 
 
 class MLMforLogitsModel(torch.nn.Module):
-    def __init__(self, model_path):
+    def __init__(self, model_path, phylo_dist_path=None):
         super().__init__()
-        self.model = load_model(model_path)
+        self.model = load_model(model_path, phylo_dist_path=phylo_dist_path)
         self.model.eval()
         tokenizer = Tokenizer()
         self.id_a = tokenizer.vocab.index("A")
@@ -52,9 +52,17 @@ class MLMforLogitsModel(torch.nn.Module):
 
 class LogitsInference(object):
     def __init__(
-        self, model_path, genome_msa_list, window_size, disable_aux_features=False
+        self,
+        model_path,
+        genome_msa_list,
+        window_size,
+        disable_aux_features=False,
+        phylo_dist_path=None,
     ):
-        self.model = MLMforLogitsModel(model_path)
+        self.model = MLMforLogitsModel(
+            model_path,
+            phylo_dist_path=phylo_dist_path,
+        )
         self.genome_msa_list = genome_msa_list
         self.window_size = window_size
         self.disable_aux_features = disable_aux_features

--- a/gpn/star/model.py
+++ b/gpn/star/model.py
@@ -962,23 +962,43 @@ class GPNStarForMaskedLM(GPNStarPreTrainedModel):
         )
 
 
-def load_model(model_path):
+def load_model(model_path, phylo_dist_path=None):
     """Load model with validated phylo_dist_path.
 
-    If config.phylo_dist_path doesn't exist on filesystem, tries fallback
-    path at model_path/phylo_dist/. Raises Exception if neither exists.
+    An explicit ``phylo_dist_path`` takes precedence over the path stored in
+    the model config. Without an override, an invalid configured path falls
+    back to ``model_path/phylo_dist``.
     """
     config = AutoConfig.from_pretrained(model_path)
+    configured_path = None
 
-    if not os.path.exists(config.phylo_dist_path):
-        fallback_path = os.path.join(model_path, "phylo_dist")
-        if os.path.exists(fallback_path):
+    if phylo_dist_path is not None:
+        phylo_dist_path = os.fsdecode(os.fspath(phylo_dist_path))
+        if not os.path.isdir(phylo_dist_path):
+            raise FileNotFoundError(
+                f"Phylogenetic-distance directory does not exist: "
+                f"'{phylo_dist_path}'"
+            )
+        config.phylo_dist_path = phylo_dist_path
+    else:
+        configured_path = getattr(config, "phylo_dist_path", None)
+        if configured_path is not None:
+            configured_path = os.fsdecode(os.fspath(configured_path))
+
+    if phylo_dist_path is None and (
+        configured_path is None or not os.path.isdir(configured_path)
+    ):
+        fallback_path = os.path.join(os.fsdecode(os.fspath(model_path)), "phylo_dist")
+        if os.path.isdir(fallback_path):
             config.phylo_dist_path = fallback_path
         else:
-            raise Exception(
-                f"phylo_dist_path '{config.phylo_dist_path}' does not exist "
-                f"and fallback path '{fallback_path}' does not exist"
+            raise FileNotFoundError(
+                f"Configured phylogenetic-distance directory "
+                f"'{configured_path}' does not exist "
+                f"and fallback directory '{fallback_path}' does not exist"
             )
+    elif phylo_dist_path is None:
+        config.phylo_dist_path = configured_path
 
     return AutoModelForMaskedLM.from_pretrained(model_path, config=config)
 

--- a/tests/test_star_checkpoint.py
+++ b/tests/test_star_checkpoint.py
@@ -1,0 +1,442 @@
+import json
+from pathlib import Path
+import stat
+
+import pandas as pd
+import pyarrow.parquet as pq
+import pytest
+
+import gpn.star.checkpoint as checkpoint
+from gpn.star.checkpoint import (
+    BatchRange,
+    CheckpointManifest,
+    CheckpointStore,
+    IncompatibleCheckpointError,
+    InvalidCheckpointError,
+    expected_batch_ranges,
+)
+
+
+def make_manifest(**overrides):
+    values = {
+        "run_signature": {
+            "command": "logits",
+            "dataset": {
+                "columns": ["chrom", "pos"],
+                "fingerprint": "dataset-v1",
+            },
+            "model": "model-v1",
+            "window_size": 128,
+        },
+        "total_rows": 7,
+        "batch_size": 3,
+    }
+    values.update(overrides)
+    return CheckpointManifest(**values)
+
+
+def make_store(tmp_path, **manifest_overrides):
+    manifest = make_manifest(**manifest_overrides)
+    store = CheckpointStore(tmp_path / "checkpoints", manifest)
+    store.initialize()
+    return store
+
+
+def frame_for(batch, value_column="prediction"):
+    return pd.DataFrame(
+        {
+            "row_id": list(range(batch.start, batch.stop)),
+            value_column: [
+                float(index) + 0.5 for index in range(batch.start, batch.stop)
+            ],
+        },
+        index=range(100 + batch.start, 100 + batch.stop),
+    )
+
+
+def populate(store, order=None):
+    order = order if order is not None else range(len(store.batches))
+    for index in order:
+        batch = store.batches[index]
+        store.write_batch(batch, frame_for(batch))
+
+
+@pytest.mark.parametrize(
+    ("total_rows", "batch_size"),
+    [
+        (0, 1),
+        (-1, 1),
+        (True, 1),
+        (1, 0),
+        (1, -1),
+        (1, True),
+    ],
+)
+def test_expected_batch_ranges_reject_invalid_sizes(total_rows, batch_size):
+    with pytest.raises(ValueError):
+        expected_batch_ranges(total_rows, batch_size)
+
+
+def test_expected_batch_ranges_are_stable_and_ordered():
+    assert expected_batch_ranges(7, 3) == (
+        BatchRange(index=0, start=0, stop=3),
+        BatchRange(index=1, start=3, stop=6),
+        BatchRange(index=2, start=6, stop=7),
+    )
+
+
+def test_manifest_normalizes_json_and_has_stable_digest():
+    first = CheckpointManifest(
+        run_signature={"options": ("a", "b"), "command": "logits"},
+        total_rows=4,
+        batch_size=2,
+    )
+    second = CheckpointManifest(
+        run_signature={"command": "logits", "options": ["a", "b"]},
+        total_rows=4,
+        batch_size=2,
+    )
+
+    assert first.run_signature["options"] == ["a", "b"]
+    assert first.digest == second.digest
+    assert CheckpointManifest.from_dict(first.to_dict()) == first
+
+
+def test_manifest_rejects_non_json_signature():
+    with pytest.raises(TypeError, match="JSON-compatible"):
+        CheckpointManifest(
+            run_signature={"not_json": object()},
+            total_rows=4,
+            batch_size=2,
+        )
+
+
+def test_initialize_is_idempotent_for_compatible_manifest(tmp_path):
+    manifest = make_manifest()
+    first = CheckpointStore(tmp_path / "checkpoints", manifest)
+    second = CheckpointStore(tmp_path / "checkpoints", manifest)
+
+    first.initialize()
+    second.initialize()
+
+    assert CheckpointManifest.read(first.manifest_path) == manifest
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"run_signature": {"command": "vep"}},
+        {"total_rows": 8},
+        {"batch_size": 2},
+    ],
+)
+def test_initialize_rejects_incompatible_manifest(tmp_path, overrides):
+    original = make_store(tmp_path)
+    requested = make_manifest(**overrides)
+
+    with pytest.raises(IncompatibleCheckpointError, match="incompatible"):
+        CheckpointStore(original.directory, requested).initialize()
+
+
+def test_initialize_rejects_old_nonempty_directory_without_manifest(tmp_path):
+    directory = tmp_path / "checkpoints"
+    directory.mkdir()
+    pd.DataFrame({"x": [1]}).to_parquet(directory / "batch_00000000.parquet")
+
+    with pytest.raises(IncompatibleCheckpointError, match="without manifest.json"):
+        CheckpointStore(directory, make_manifest()).initialize()
+
+
+def test_tampered_manifest_is_rejected(tmp_path):
+    store = make_store(tmp_path)
+    value = json.loads(store.manifest_path.read_text())
+    value["total_rows"] = 8
+    store.manifest_path.write_text(json.dumps(value))
+
+    with pytest.raises(InvalidCheckpointError, match="digest"):
+        store.completed_batch_indices()
+
+
+def test_manifest_write_is_atomic(tmp_path, monkeypatch):
+    store = CheckpointStore(tmp_path / "checkpoints", make_manifest())
+    real_replace = checkpoint.os.replace
+
+    def fail_manifest_replace(source, destination):
+        if Path(destination) == store.manifest_path:
+            raise OSError("simulated replacement failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(checkpoint.os, "replace", fail_manifest_replace)
+
+    with pytest.raises(OSError, match="simulated"):
+        store.initialize()
+
+    assert not store.manifest_path.exists()
+    assert list(store.directory.iterdir()) == []
+
+
+def test_write_and_resume_accept_only_committed_batches(tmp_path):
+    store = make_store(tmp_path)
+    store.write_batch(0, frame_for(store.batches[0]))
+    store.write_batch(2, frame_for(store.batches[2]))
+
+    resumed = CheckpointStore(store.directory, store.manifest)
+    resumed.initialize()
+
+    assert resumed.completed_batch_indices() == (0, 2)
+    assert resumed.validate_batch(1) is None
+
+
+def test_write_batch_does_not_rescan_prior_batches(tmp_path, monkeypatch):
+    store = make_store(tmp_path, total_rows=20, batch_size=1)
+    assert store.completed_batch_indices() == ()
+    calls = []
+    original_validate_batch = store.validate_batch
+
+    def record_validation(batch, expected_schema=None):
+        calls.append(batch.index if isinstance(batch, BatchRange) else batch)
+        return original_validate_batch(batch, expected_schema)
+
+    monkeypatch.setattr(store, "validate_batch", record_validation)
+
+    for batch in store.batches:
+        store.write_batch(batch, frame_for(batch))
+
+    assert calls == list(range(len(store.batches)))
+
+
+def test_write_batch_is_atomic(tmp_path, monkeypatch):
+    store = make_store(tmp_path)
+    batch = store.batches[0]
+    target = store.batch_path(batch)
+    real_replace = checkpoint.os.replace
+
+    def fail_batch_replace(source, destination):
+        if Path(destination) == target:
+            raise OSError("simulated replacement failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(checkpoint.os, "replace", fail_batch_replace)
+
+    with pytest.raises(OSError, match="simulated"):
+        store.write_batch(batch, frame_for(batch))
+
+    assert not target.exists()
+    assert not list(store.directory.glob(f".{target.name}.*.tmp"))
+    assert store.completed_batch_indices() == ()
+
+
+def test_atomic_parquet_permissions_follow_umask_and_preserve_existing_mode(
+    tmp_path,
+):
+    store = make_store(tmp_path)
+    batch = store.batches[0]
+    batch_path = store.write_batch(batch, frame_for(batch))
+
+    assert stat.S_IMODE(batch_path.stat().st_mode) == checkpoint.DEFAULT_FILE_MODE
+
+    populate(store, order=[1, 2])
+    output = tmp_path / "output.parquet"
+    output.write_bytes(b"old output")
+    output.chmod(0o640)
+    store.combine_to(output)
+
+    assert stat.S_IMODE(output.stat().st_mode) == 0o640
+
+
+def test_write_batch_validates_type_and_row_count(tmp_path):
+    store = make_store(tmp_path)
+
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        store.write_batch(0, [{"prediction": 1.0}])
+    with pytest.raises(ValueError, match="expects 3"):
+        store.write_batch(0, pd.DataFrame({"prediction": [1.0]}))
+
+
+def test_write_batch_refuses_to_overwrite_committed_file(tmp_path):
+    store = make_store(tmp_path)
+    batch = store.batches[0]
+    store.write_batch(batch, frame_for(batch))
+
+    with pytest.raises(FileExistsError, match="already committed"):
+        store.write_batch(batch, frame_for(batch))
+
+
+def test_wrong_batch_range_is_rejected(tmp_path):
+    store = make_store(tmp_path)
+    wrong = BatchRange(index=0, start=0, stop=2)
+
+    with pytest.raises(ValueError, match="does not match"):
+        store.write_batch(wrong, pd.DataFrame({"prediction": [1.0, 2.0]}))
+
+
+def test_negative_batch_index_is_rejected(tmp_path):
+    store = make_store(tmp_path)
+
+    with pytest.raises(IndexError, match="out of range"):
+        store.batch_path(-1)
+
+
+def test_batch_without_checkpoint_metadata_is_rejected(tmp_path):
+    store = make_store(tmp_path)
+    batch = store.batches[0]
+    pd.DataFrame({"prediction": [1.0, 2.0, 3.0]}).to_parquet(
+        store.batch_path(batch),
+        index=False,
+    )
+
+    with pytest.raises(InvalidCheckpointError, match="lacks GPN metadata"):
+        store.validate_batch(batch)
+
+
+def test_corrupt_batch_is_rejected(tmp_path):
+    store = make_store(tmp_path)
+    store.batch_path(0).write_bytes(b"not a parquet file")
+
+    with pytest.raises(InvalidCheckpointError, match="Could not read"):
+        store.completed_batch_indices()
+
+
+def test_wrong_batch_row_count_is_rejected(tmp_path):
+    store = make_store(tmp_path)
+    batch = store.batches[0]
+    store.write_batch(batch, frame_for(batch))
+    table = pq.read_table(store.batch_path(batch)).slice(0, 2)
+    pq.write_table(table, store.batch_path(batch))
+
+    with pytest.raises(InvalidCheckpointError, match="has 2 rows; expected 3"):
+        store.validate_batch(batch)
+
+
+def test_cross_batch_schema_mismatch_is_rejected_before_commit(tmp_path):
+    store = make_store(tmp_path)
+    store.write_batch(0, frame_for(store.batches[0]))
+    second = store.batches[1]
+    incompatible = pd.DataFrame(
+        {
+            "row_id": [str(index) for index in range(second.start, second.stop)],
+            "prediction": ["x"] * second.num_rows,
+        }
+    )
+
+    with pytest.raises(InvalidCheckpointError, match="different schema"):
+        store.write_batch(second, incompatible)
+
+    assert not store.batch_path(second).exists()
+
+
+def test_unexpected_batch_file_is_rejected(tmp_path):
+    store = make_store(tmp_path)
+    pd.DataFrame({"x": [1]}).to_parquet(
+        store.directory / "batch_99999999.parquet",
+        index=False,
+    )
+
+    with pytest.raises(InvalidCheckpointError, match="Unexpected"):
+        store.completed_batch_indices()
+
+
+def test_combine_requires_every_batch(tmp_path):
+    store = make_store(tmp_path)
+    store.write_batch(0, frame_for(store.batches[0]))
+
+    with pytest.raises(InvalidCheckpointError, match="missing.*1, 2"):
+        store.combine_to(tmp_path / "output.parquet")
+
+
+def test_combine_uses_numeric_batch_order_and_drops_dataframe_index(tmp_path):
+    store = make_store(tmp_path)
+    populate(store, order=[2, 0, 1])
+
+    output = store.combine_to(tmp_path / "output.parquet")
+    result = pd.read_parquet(output)
+
+    assert result["row_id"].tolist() == list(range(7))
+    assert result.columns.tolist() == ["row_id", "prediction"]
+    assert store.validate_final(output).names == ["row_id", "prediction"]
+
+
+def test_final_write_is_atomic_and_preserves_existing_output_on_failure(
+    tmp_path,
+    monkeypatch,
+):
+    store = make_store(tmp_path)
+    populate(store)
+    output = tmp_path / "output.parquet"
+    original = b"previous complete output"
+    output.write_bytes(original)
+    real_replace = checkpoint.os.replace
+
+    def fail_final_replace(source, destination):
+        if Path(destination) == output:
+            raise OSError("simulated final replacement failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(checkpoint.os, "replace", fail_final_replace)
+
+    with pytest.raises(OSError, match="simulated"):
+        store.combine_to(output)
+
+    assert output.read_bytes() == original
+    assert store.completed_batch_indices() == (0, 1, 2)
+    assert not list(tmp_path.glob(f".{output.name}.*.tmp"))
+
+
+def test_final_output_must_be_outside_checkpoint_directory(tmp_path):
+    store = make_store(tmp_path)
+    populate(store)
+
+    with pytest.raises(ValueError, match="outside"):
+        store.combine_to(store.directory / "output.parquet")
+
+
+def test_validate_final_rejects_unrelated_parquet(tmp_path):
+    store = make_store(tmp_path)
+    populate(store)
+    unrelated = tmp_path / "unrelated.parquet"
+    pd.concat([frame_for(batch) for batch in store.batches]).to_parquet(
+        unrelated,
+        index=False,
+    )
+
+    with pytest.raises(InvalidCheckpointError, match="lacks GPN provenance"):
+        store.validate_final(unrelated)
+
+
+def test_cleanup_requires_matching_committed_final_output(tmp_path):
+    store = make_store(tmp_path)
+    populate(store)
+    unrelated = tmp_path / "unrelated.parquet"
+    pd.concat([frame_for(batch) for batch in store.batches]).to_parquet(
+        unrelated,
+        index=False,
+    )
+
+    with pytest.raises(InvalidCheckpointError, match="provenance"):
+        store.cleanup(unrelated)
+
+    assert store.manifest_path.exists()
+    assert store.completed_batch_indices() == (0, 1, 2)
+
+
+def test_cleanup_runs_after_final_commit_and_removes_managed_directory(tmp_path):
+    store = make_store(tmp_path)
+    populate(store)
+    output = store.combine_to(tmp_path / "output.parquet")
+
+    assert store.cleanup(output) is True
+    assert output.is_file()
+    assert not store.directory.exists()
+
+
+def test_cleanup_preserves_unknown_files_and_manifest(tmp_path):
+    store = make_store(tmp_path)
+    populate(store)
+    output = store.combine_to(tmp_path / "output.parquet")
+    sentinel = store.directory / "keep-me.txt"
+    sentinel.write_text("user data")
+
+    assert store.cleanup(output) is False
+    assert sentinel.read_text() == "user data"
+    assert store.manifest_path.is_file()
+    assert all(not store.batch_path(batch).exists() for batch in store.batches)

--- a/tests/test_star_inference_checkpointing.py
+++ b/tests/test_star_inference_checkpointing.py
@@ -1,0 +1,381 @@
+from pathlib import Path
+import stat
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import gpn.star.inference as inference_module
+from gpn.star.checkpoint import DEFAULT_FILE_MODE, IncompatibleCheckpointError
+
+
+class FakeDataset:
+    column_names = ["value"]
+    _fingerprint = "fake-dataset-v1"
+
+    def __init__(self, values):
+        self.values = list(values)
+        self.transform = None
+
+    def __len__(self):
+        return len(self.values)
+
+    def set_transform(self, transform):
+        self.transform = transform
+
+    def select(self, indices):
+        selected = FakeDataset([self.values[index] for index in indices])
+        selected.transform = self.transform
+        return selected
+
+
+class FakeInference:
+    model = object()
+
+    @staticmethod
+    def tokenize_function(batch):
+        return batch
+
+    @staticmethod
+    def postprocess(predictions):
+        return pd.DataFrame({"score": predictions[:, 0]})
+
+
+class FakeTrainer:
+    def __init__(self, fail_on_call=None, is_main_process=True, num_processes=1):
+        self.accelerator = SimpleNamespace(
+            is_main_process=is_main_process,
+            num_processes=num_processes,
+        )
+        self.fail_on_call = fail_on_call
+        self.calls = []
+
+    def predict(self, test_dataset):
+        self.calls.append(list(test_dataset.values))
+        if self.fail_on_call == len(self.calls):
+            raise RuntimeError("simulated interruption")
+        predictions = np.asarray(test_dataset.values, dtype=float)[:, None]
+        return SimpleNamespace(predictions=predictions)
+
+
+def run_checkpointed(
+    monkeypatch,
+    tmp_path,
+    trainer,
+    *,
+    dataset=None,
+    signature=None,
+    cleanup=False,
+):
+    dataset = dataset if dataset is not None else FakeDataset(range(7))
+    signature = signature or {
+        "command": "logits",
+        "dataset": {"fingerprint": dataset._fingerprint},
+        "model": {"config": "v1"},
+    }
+    trainer_factory_calls = []
+
+    def fake_create_trainer(*args, **kwargs):
+        trainer_factory_calls.append((args, kwargs))
+        return trainer
+
+    monkeypatch.setattr(
+        inference_module,
+        "_create_trainer",
+        fake_create_trainer,
+    )
+    output = tmp_path / "predictions.parquet"
+    checkpoints = tmp_path / "checkpoints"
+    result = inference_module.run_inference_with_checkpoints(
+        dataset,
+        FakeInference(),
+        output_path=output,
+        checkpoint_dir=checkpoints,
+        checkpoint_batch_size=3,
+        run_signature=signature,
+        per_device_batch_size=2,
+        dataloader_num_workers=0,
+        cleanup_checkpoints=cleanup,
+    )
+    return result, output, checkpoints, trainer_factory_calls
+
+
+def test_interrupted_run_resumes_only_missing_batches_in_row_order(
+    monkeypatch,
+    tmp_path,
+):
+    interrupted_trainer = FakeTrainer(fail_on_call=2)
+    with pytest.raises(RuntimeError, match="simulated interruption"):
+        run_checkpointed(monkeypatch, tmp_path, interrupted_trainer)
+
+    checkpoints = tmp_path / "checkpoints"
+    assert interrupted_trainer.calls == [[0, 1, 2], [3, 4, 5]]
+    assert sorted(path.name for path in checkpoints.glob("batch_*.parquet")) == [
+        "batch_00000000.parquet"
+    ]
+    assert not (tmp_path / "predictions.parquet").exists()
+
+    resumed_trainer = FakeTrainer()
+    result, output, _, factory_calls = run_checkpointed(
+        monkeypatch,
+        tmp_path,
+        resumed_trainer,
+    )
+
+    assert result == output
+    assert len(factory_calls) == 1
+    assert resumed_trainer.calls == [[3, 4, 5], [6]]
+    assert pd.read_parquet(output)["score"].tolist() == list(np.arange(7, dtype=float))
+
+
+def test_incompatible_resume_is_rejected_before_prediction(
+    monkeypatch,
+    tmp_path,
+):
+    with pytest.raises(RuntimeError, match="simulated interruption"):
+        run_checkpointed(
+            monkeypatch,
+            tmp_path,
+            FakeTrainer(fail_on_call=2),
+        )
+
+    trainer = FakeTrainer()
+    with pytest.raises(IncompatibleCheckpointError, match="incompatible"):
+        run_checkpointed(
+            monkeypatch,
+            tmp_path,
+            trainer,
+            signature={
+                "command": "logits",
+                "dataset": {"fingerprint": "different-dataset"},
+                "model": {"config": "v1"},
+            },
+        )
+
+    assert trainer.calls == []
+    assert not (tmp_path / "predictions.parquet").exists()
+
+
+def test_cleanup_occurs_only_after_final_output_is_committed(
+    monkeypatch,
+    tmp_path,
+):
+    result, output, checkpoints, _ = run_checkpointed(
+        monkeypatch,
+        tmp_path,
+        FakeTrainer(),
+        cleanup=True,
+    )
+
+    assert result == output
+    assert output.is_file()
+    assert pd.read_parquet(output)["score"].tolist() == list(np.arange(7, dtype=float))
+    assert not checkpoints.exists()
+
+
+@pytest.mark.parametrize(
+    ("dataset", "checkpoint_batch_size", "message"),
+    [
+        (FakeDataset([]), 3, "at least one row"),
+        (FakeDataset([1]), 0, "checkpoint_batch_size must be positive"),
+    ],
+)
+def test_invalid_inputs_fail_before_filesystem_mutation(
+    monkeypatch,
+    tmp_path,
+    dataset,
+    checkpoint_batch_size,
+    message,
+):
+    monkeypatch.setattr(
+        inference_module,
+        "_create_trainer",
+        lambda *args, **kwargs: pytest.fail("Trainer should not be created"),
+    )
+    checkpoints = tmp_path / "checkpoints"
+
+    with pytest.raises(ValueError, match=message):
+        inference_module.run_inference_with_checkpoints(
+            dataset,
+            FakeInference(),
+            output_path=tmp_path / "predictions.parquet",
+            checkpoint_dir=checkpoints,
+            checkpoint_batch_size=checkpoint_batch_size,
+            run_signature={"command": "logits"},
+        )
+
+    assert not checkpoints.exists()
+
+
+def test_non_main_process_does_not_execute_filesystem_operation(monkeypatch):
+    trainer = FakeTrainer(is_main_process=False, num_processes=2)
+    called = False
+
+    def operation():
+        nonlocal called
+        called = True
+
+    def fake_broadcast(payload, from_process):
+        assert from_process == 0
+        assert payload == [None]
+        payload[0] = {"ok": True, "value": "rank-zero-result"}
+
+    monkeypatch.setattr(
+        inference_module,
+        "broadcast_object_list",
+        fake_broadcast,
+    )
+
+    result = inference_module._call_on_main_process(
+        trainer,
+        operation,
+        "test operation",
+    )
+
+    assert result == "rank-zero-result"
+    assert called is False
+
+
+def test_worker_receives_rank_zero_checkpoint_error(monkeypatch):
+    trainer = FakeTrainer(is_main_process=False, num_processes=2)
+
+    def fake_broadcast(payload, from_process):
+        payload[0] = {
+            "ok": False,
+            "error_type": "InvalidCheckpointError",
+            "error": "corrupt batch",
+        }
+
+    monkeypatch.setattr(
+        inference_module,
+        "broadcast_object_list",
+        fake_broadcast,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="InvalidCheckpointError: corrupt batch",
+    ):
+        inference_module._call_on_main_process(
+            trainer,
+            lambda: None,
+            "Resume audit",
+        )
+
+
+def test_run_signature_tracks_source_revision_resource_metadata_and_msa_order(
+    tmp_path,
+):
+    input_path = tmp_path / "positions.parquet"
+    input_path.write_bytes(b"positions")
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    (model_path / "config.json").write_text('{"model_type": "GPNStar"}')
+    first_msa = tmp_path / "first.zarr"
+    second_msa = tmp_path / "second.zarr"
+    for msa_path in [first_msa, second_msa]:
+        msa_path.mkdir()
+        (msa_path / ".zgroup").write_text('{"zarr_format": 2}')
+        chromosome = msa_path / "chr1"
+        chromosome.mkdir()
+        (chromosome / ".zarray").write_text('{"shape": [10, 2]}')
+
+    config = SimpleNamespace(
+        phylo_dist_path=None,
+        _commit_hash="model-commit",
+        to_dict=lambda: {"model_type": "GPNStar"},
+    )
+    model = SimpleNamespace(model=SimpleNamespace(config=config))
+    fake_inference = SimpleNamespace(model=model)
+    args = SimpleNamespace(
+        checkpoint_revision="msa-release-2",
+        command="logits",
+        input_path=str(input_path),
+        is_file=True,
+        split="test",
+        center_window_size=None,
+        disable_aux_features=False,
+        window_size=128,
+        model_path=str(model_path),
+    )
+    msa_paths = {
+        100: str(first_msa),
+        36: str(second_msa),
+    }
+
+    signature = inference_module.build_run_signature(
+        args,
+        FakeDataset([1]),
+        msa_paths,
+        fake_inference,
+    )
+
+    assert signature["checkpoint_revision"] == "msa-release-2"
+    assert signature["software"]["gpn_source"]["sha256"]
+    assert signature["model"]["config"]["commit_hash"] == "model-commit"
+    assert [(item["order"], item["n_species"]) for item in signature["msa"]] == [
+        (0, "100"),
+        (1, "36"),
+    ]
+    assert all(
+        item["resource"]["tree"]["strategy"] == "zarr-metadata-and-array-directories-v1"
+        for item in signature["msa"]
+    )
+
+
+def test_direct_inference_reuses_main_process_semantics(monkeypatch):
+    trainer = FakeTrainer()
+    monkeypatch.setattr(
+        inference_module,
+        "_create_trainer",
+        lambda *args, **kwargs: trainer,
+    )
+
+    result = inference_module.run_inference(
+        FakeDataset([2, 4]),
+        FakeInference(),
+    )
+
+    assert trainer.calls == [[2, 4]]
+    assert result["score"].tolist() == [2.0, 4.0]
+
+
+def test_atomic_direct_write_preserves_existing_output_on_failure(
+    monkeypatch,
+    tmp_path,
+):
+    output = tmp_path / "predictions.parquet"
+    original = b"previous output"
+    output.write_bytes(original)
+
+    def fail_replace(source, destination):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(inference_module.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated"):
+        inference_module._write_parquet_atomic(
+            pd.DataFrame({"score": [1.0]}),
+            output,
+        )
+
+    assert output.read_bytes() == original
+    assert list(tmp_path.glob(".predictions.parquet.*.tmp")) == []
+
+
+def test_atomic_direct_write_uses_normal_permissions_and_preserves_mode(tmp_path):
+    output = tmp_path / "predictions.parquet"
+
+    inference_module._write_parquet_atomic(
+        pd.DataFrame({"score": [1.0]}),
+        output,
+    )
+    assert stat.S_IMODE(output.stat().st_mode) == DEFAULT_FILE_MODE
+
+    output.chmod(0o640)
+    inference_module._write_parquet_atomic(
+        pd.DataFrame({"score": [2.0]}),
+        output,
+    )
+    assert stat.S_IMODE(output.stat().st_mode) == 0o640

--- a/tests/test_star_model_loading.py
+++ b/tests/test_star_model_loading.py
@@ -1,0 +1,189 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gpn.star import logits as logits_module
+from gpn.star import model as model_module
+
+
+def mock_huggingface_load(monkeypatch, configured_phylo_dist_path):
+    config = SimpleNamespace(phylo_dist_path=configured_phylo_dist_path)
+    loaded_model = object()
+    calls = {}
+
+    def fake_load_config(model_path):
+        calls["config_model_path"] = model_path
+        return config
+
+    def fake_load_model(model_path, *, config):
+        calls["model_path"] = model_path
+        calls["config"] = config
+        return loaded_model
+
+    monkeypatch.setattr(
+        model_module.AutoConfig,
+        "from_pretrained",
+        fake_load_config,
+    )
+    monkeypatch.setattr(
+        model_module.AutoModelForMaskedLM,
+        "from_pretrained",
+        fake_load_model,
+    )
+    return config, loaded_model, calls
+
+
+def test_explicit_phylo_dist_override_wins(monkeypatch, tmp_path):
+    configured_path = tmp_path / "configured"
+    configured_path.mkdir()
+    override_path = tmp_path / "override"
+    override_path.mkdir()
+    config, loaded_model, calls = mock_huggingface_load(
+        monkeypatch,
+        str(configured_path),
+    )
+
+    result = model_module.load_model(
+        "model",
+        phylo_dist_path=str(override_path),
+    )
+
+    assert result is loaded_model
+    assert config.phylo_dist_path == str(override_path)
+    assert calls == {
+        "config_model_path": "model",
+        "model_path": "model",
+        "config": config,
+    }
+
+
+def test_explicit_pathlike_override_is_normalized(monkeypatch, tmp_path):
+    configured_path = tmp_path / "configured"
+    configured_path.mkdir()
+    override_path = tmp_path / "override"
+    override_path.mkdir()
+    config, _, _ = mock_huggingface_load(monkeypatch, str(configured_path))
+
+    model_module.load_model("model", phylo_dist_path=override_path)
+
+    assert config.phylo_dist_path == str(override_path)
+
+
+def test_existing_configured_phylo_dist_path_is_preserved(monkeypatch, tmp_path):
+    configured_path = tmp_path / "configured"
+    configured_path.mkdir()
+    config, loaded_model, calls = mock_huggingface_load(
+        monkeypatch,
+        str(configured_path),
+    )
+
+    result = model_module.load_model("model")
+
+    assert result is loaded_model
+    assert config.phylo_dist_path == str(configured_path)
+    assert calls["config"] is config
+
+
+@pytest.mark.parametrize("missing_attribute", [False, True])
+def test_null_or_missing_configured_path_uses_model_fallback(
+    monkeypatch,
+    tmp_path,
+    missing_attribute,
+):
+    model_path = tmp_path / "model"
+    fallback_path = model_path / "phylo_dist"
+    fallback_path.mkdir(parents=True)
+    config, loaded_model, _ = mock_huggingface_load(monkeypatch, None)
+    if missing_attribute:
+        del config.phylo_dist_path
+
+    result = model_module.load_model(model_path)
+
+    assert result is loaded_model
+    assert config.phylo_dist_path == str(fallback_path)
+
+
+def test_missing_configured_path_uses_model_fallback(monkeypatch, tmp_path):
+    model_path = tmp_path / "model"
+    fallback_path = model_path / "phylo_dist"
+    fallback_path.mkdir(parents=True)
+    config, loaded_model, calls = mock_huggingface_load(
+        monkeypatch,
+        str(tmp_path / "missing-configured"),
+    )
+
+    result = model_module.load_model(str(model_path))
+
+    assert result is loaded_model
+    assert config.phylo_dist_path == str(fallback_path)
+    assert calls["model_path"] == str(model_path)
+
+
+def test_invalid_explicit_override_raises_even_when_fallback_exists(
+    monkeypatch,
+    tmp_path,
+):
+    model_path = tmp_path / "model"
+    (model_path / "phylo_dist").mkdir(parents=True)
+    mock_huggingface_load(monkeypatch, str(tmp_path / "configured"))
+    missing_override = tmp_path / "missing-override"
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="Phylogenetic-distance directory does not exist",
+    ):
+        model_module.load_model(
+            str(model_path),
+            phylo_dist_path=str(missing_override),
+        )
+
+
+def test_missing_configured_and_fallback_paths_raise(monkeypatch, tmp_path):
+    model_path = tmp_path / "model"
+    configured_path = tmp_path / "missing-configured"
+    mock_huggingface_load(monkeypatch, str(configured_path))
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="fallback directory",
+    ) as error:
+        model_module.load_model(str(model_path))
+
+    assert str(configured_path) in str(error.value)
+    assert str(model_path / "phylo_dist") in str(error.value)
+
+
+def test_mlm_for_logits_forwards_phylo_dist_override(monkeypatch):
+    calls = {}
+
+    class FakeModel(logits_module.torch.nn.Module):
+        def eval(self):
+            calls["eval"] = True
+            return self
+
+    class FakeTokenizer:
+        vocab = ["A", "C", "G", "T"]
+
+    def fake_load_model(model_path, phylo_dist_path=None):
+        calls["load"] = (model_path, phylo_dist_path)
+        return FakeModel()
+
+    monkeypatch.setattr(logits_module, "load_model", fake_load_model)
+    monkeypatch.setattr(logits_module, "Tokenizer", FakeTokenizer)
+
+    wrapped_model = logits_module.MLMforLogitsModel(
+        "model",
+        phylo_dist_path="override",
+    )
+
+    assert calls == {
+        "load": ("model", "override"),
+        "eval": True,
+    }
+    assert isinstance(wrapped_model.model, FakeModel)
+    assert (
+        wrapped_model.id_a,
+        wrapped_model.id_c,
+        wrapped_model.id_g,
+        wrapped_model.id_t,
+    ) == (0, 1, 2, 3)


### PR DESCRIPTION
## Summary

- Selectively port the durable inference work from the divergent inference branch.
- Add validated, atomic checkpoint/resume support with stable batch ranges and rank-zero-only file operations.
- Preserve main's phylogenetic-distance fallback while adding an explicit logits override.
- Wire checkpointing into the existing generic get_logits workflow path and add the missing get_llr imports.
- Add the calibrated absolute-LLR rule with the inference-branch formula abs(LLR) - abs(neutral mean).

## Scope

This intentionally does not merge the historical inference branch. It excludes result files, notebooks, personal launchers and paths, experimental rule-all/dataset/model toggles, and path rewrites that break downstream logits processing. The absLLR rule is available on demand but is not added to any default rule-all target.

Zarr inputs are treated as immutable during a resumed run. The CLI provides checkpoint_revision for in-place MSA chunk revisions that automatic metadata checks cannot detect.

## Validation

- 57 focused tests passed.
- Changed Python files compile and the staged diff passes whitespace checks.
- All six species Snakefiles parse; dry-run DAG checks preserve get_logits -> process_logits -> get_llr and the existing VEP route.
- A concrete absLLR dry run selected exactly get_absllr_calibrated with the intended inputs and wildcards.
- A two-process CPU torchrun smoke verified rank-zero writes, error propagation, ordered assembly, and coordinated resume. Real multi-GPU model inference was not exercised.