### PR TITLE
Bump version to 0.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_requires = [
 
 setup(
     name="gpn",
-    version="0.7",
+    version="0.8",
     description="gpn",
     url="http://github.com/songlab-cal/gpn",
     author="Gonzalo Benegas, Chengzhong Ye",


### PR DESCRIPTION
## Summary
- bump the Python package version from 0.7 to 0.8
- retain the frozen GPN-Star analysis environment as originally recorded

## Validation
- `python setup.py --name --version` reports `gpn` / `0.8`
- `57 passed` in the GPN-Star test suite