### PR TITLE
Add GPN-Star scores to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ model = AutoModelForMaskedLM.from_pretrained("songlab/gpn-msa-sapiens")
   - Training regions: [gpn-msa-sapiens-dataset](https://huggingface.co/datasets/songlab/gpn-msa-sapiens-dataset)
 - **Models:**
   - [gpn-msa-sapiens](https://huggingface.co/songlab/gpn-msa-sapiens)
+- **Additional resources:**
+  - [Genome-wide scores and UCSC Genome Browser tracks](https://huggingface.co/datasets/songlab/gpn-star-scores)
 - **Benchmark datasets (including predictions from all models):**
   - [ClinVar](https://huggingface.co/datasets/songlab/clinvar) - Missense variants with clinical pathogenic/benign labels
   - [COSMIC](https://huggingface.co/datasets/songlab/cosmic) - Somatic missense mutations in cancer

--- a/README.md
+++ b/README.md
@@ -187,8 +187,6 @@ model = AutoModelForMaskedLM.from_pretrained("songlab/gpn-msa-sapiens")
   - Training regions: [gpn-msa-sapiens-dataset](https://huggingface.co/datasets/songlab/gpn-msa-sapiens-dataset)
 - **Models:**
   - [gpn-msa-sapiens](https://huggingface.co/songlab/gpn-msa-sapiens)
-- **Additional resources:**
-  - [Genome-wide scores and UCSC Genome Browser tracks](https://huggingface.co/datasets/songlab/gpn-star-scores)
 - **Benchmark datasets (including predictions from all models):**
   - [ClinVar](https://huggingface.co/datasets/songlab/clinvar) - Missense variants with clinical pathogenic/benign labels
   - [COSMIC](https://huggingface.co/datasets/songlab/cosmic) - Somatic missense mutations in cancer
@@ -245,6 +243,7 @@ model = AutoModelForMaskedLM.from_pretrained("songlab/gpn-star-hg38-p243-200m")
 #### [Ye, Benegas, Albors, Li, Prillo, Fields, Clarke and Song "Predicting functional constraints across evolutionary timescales with phylogeny-informed genomic language models" *bioRxiv* (2025)](https://doi.org/10.1101/2025.09.21.677619)
 
 - **Collection:** [HuggingFace 🤗](https://huggingface.co/collections/songlab/gpn-star-68c0c055acc2ee51d5c4f129)
+- **Genome-wide scores and UCSC Genome Browser tracks:** [gpn-star-scores](https://huggingface.co/datasets/songlab/gpn-star-scores)
 - **Pretraining datasets:**
   - Vertebrate alignment: [multiz100way](https://huggingface.co/datasets/songlab/multiz100way-pigz) (100 species)
   - Mammalian alignment: [cactus447way](https://huggingface.co/datasets/songlab/hg38_cactus447way) (447 species)


### PR DESCRIPTION
## Summary

- Link the GPN-Star genome-wide scores from the README.
- Note that the dataset also provides UCSC Genome Browser tracks.

## Validation

- Confirmed the PR changes only one line in `README.md`.