### PR TITLE
Link the hosted Read the Docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # GPN — Genomic Pretrained Network
 
 [![CI](https://github.com/songlab-cal/gpn/actions/workflows/ci.yml/badge.svg)](https://github.com/songlab-cal/gpn/actions/workflows/ci.yml)
+[![Documentation](https://readthedocs.org/projects/gpn/badge/?version=latest)](https://gpn.readthedocs.io/)
 [![PyPI](https://img.shields.io/pypi/v/gpn)](https://pypi.org/project/gpn/)
 [![Python 3.13](https://img.shields.io/badge/Python-3.13-blue)](https://www.python.org/downloads/release/python-3130/)
 [![License](https://img.shields.io/github/license/songlab-cal/gpn)](https://github.com/songlab-cal/gpn/blob/main/LICENSE)
 
 [**Quick start**](#quick-start) · [**Model families**](#model-families) ·
-[**Demos**](#demos) · [**Documentation**](https://github.com/songlab-cal/gpn/blob/main/docs/index.md)
+[**Demos**](#demos) · [**Documentation**](https://gpn.readthedocs.io/)
 
 ![GPN-Star architecture, evolutionary scales, and genomic prediction tasks](docs/_static/gpn_star_overview.png)
 
@@ -28,16 +29,16 @@ register_auto_classes("star")
 model = AutoModelForMaskedLM.from_pretrained("songlab/gpn-star-hg38-v100-200m")
 ```
 
-Explore the [GPN-Star models, alignments, scores, and benchmark datasets](https://github.com/songlab-cal/gpn/blob/main/docs/models/gpn-star.md#published-assets).
+Explore the [GPN-Star models, alignments, scores, and benchmark datasets](https://gpn.readthedocs.io/en/latest/models/gpn-star/#published-assets).
 
 ## Model families
 
 | Model | Paper | Notes |
 | --- | --- | --- |
-| [GPN](https://github.com/songlab-cal/gpn/blob/main/docs/models/gpn.md) | [Benegas et al. 2023](https://doi.org/10.1073/pnas.2311219120) | Requires unaligned genomes |
-| [GPN-MSA](https://github.com/songlab-cal/gpn/blob/main/docs/models/gpn-msa.md) | [Benegas et al. 2025](https://www.nature.com/articles/s41587-024-02511-w) | Requires aligned genomes for training and inference; deprecated in favor of GPN-Star |
-| [PhyloGPN](https://github.com/songlab-cal/gpn/blob/main/docs/models/phylogpn.md) | [Albors et al. 2025](https://link.springer.com/chapter/10.1007/978-3-031-90252-9_7) | Uses an alignment during training, but does not require it for inference or fine-tuning |
-| [GPN-Star](https://github.com/songlab-cal/gpn/blob/main/docs/models/gpn-star.md) | [Ye et al. 2025](https://doi.org/10.1101/2025.09.21.677619) | Requires aligned genomes for training and inference |
+| [GPN](https://gpn.readthedocs.io/en/latest/models/gpn/) | [Benegas et al. 2023](https://doi.org/10.1073/pnas.2311219120) | Requires unaligned genomes |
+| [GPN-MSA](https://gpn.readthedocs.io/en/latest/models/gpn-msa/) | [Benegas et al. 2025](https://www.nature.com/articles/s41587-024-02511-w) | Requires aligned genomes for training and inference; deprecated in favor of GPN-Star |
+| [PhyloGPN](https://gpn.readthedocs.io/en/latest/models/phylogpn/) | [Albors et al. 2025](https://link.springer.com/chapter/10.1007/978-3-031-90252-9_7) | Uses an alignment during training, but does not require it for inference or fine-tuning |
+| [GPN-Star](https://gpn.readthedocs.io/en/latest/models/gpn-star/) | [Ye et al. 2025](https://doi.org/10.1101/2025.09.21.677619) | Requires aligned genomes for training and inference |
 
 ## Command line
 
@@ -49,7 +50,7 @@ gpn msa {vep,logits,embedding} ...
 gpn star {train,vep,logits,embedding} ...
 ```
 
-See the [CLI guide](https://github.com/songlab-cal/gpn/blob/main/docs/getting-started/cli.md) for inputs, outputs, and multi-GPU inference.
+See the [CLI guide](https://gpn.readthedocs.io/en/latest/getting-started/cli/) for inputs, outputs, and multi-GPU inference.
 
 ## Training
 
@@ -68,7 +69,7 @@ The paper analyses and retired research workflows are preserved in the [`analysi
 
 ## Development and help
 
-See the [documentation](https://github.com/songlab-cal/gpn/blob/main/docs/index.md), ask questions in [Discussions](https://github.com/songlab-cal/gpn/discussions), or report problems in [Issues](https://github.com/songlab-cal/gpn/issues).
+See the [documentation](https://gpn.readthedocs.io/), ask questions in [Discussions](https://github.com/songlab-cal/gpn/discussions), or report problems in [Issues](https://github.com/songlab-cal/gpn/issues).
 
 GPN is developed in the [Song Lab at UC Berkeley](https://people.eecs.berkeley.edu/~yss/group.html) and distributed under the [MIT License](https://github.com/songlab-cal/gpn/blob/main/LICENSE).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ train = [
 tracking = ["wandb>=0.18"]
 
 [project.urls]
+Documentation = "https://gpn.readthedocs.io/"
 Issues = "https://github.com/songlab-cal/gpn/issues"
 Repository = "https://github.com/songlab-cal/gpn"
 Changelog = "https://github.com/songlab-cal/gpn/blob/main/CHANGELOG.md"

--- a/release/0.9.0/review.md
+++ b/release/0.9.0/review.md
@@ -1,20 +1,23 @@
 # GPN 0.9.0 review packet
 
-Status: **review candidate; no merge, release, tag, setting change, deployment,
-or Hugging Face write is authorized by this file.**
+Status: **the modernization was merged to `main`; version 0.9.0 remains
+unreleased. No release, tag, repository-setting change, or Hugging Face write is
+authorized by this file.**
 
-The single pull request, [#100](https://github.com/songlab-cal/gpn/pull/100),
-against `main` is the binding review surface for the complete modernization. Its
-body records the exact head commit and Git tree after this packet is committed.
-Because a Git object cannot contain its own hash, those two identifiers cannot be
-embedded in this file; final maintainer approval must repeat both identifiers
-from the pull request body.
+The single pull request, [#100](https://github.com/songlab-cal/gpn/pull/100), was
+the binding review surface for the complete modernization. It was squash-merged
+as `ebb3df3548fc8f364c339f0e5ddad86330c1f949`; the resulting tree
+`aebc93d290f5d202511827be724cec70acefe07a` matched the approved PR tree. The
+subsequent documentation-hosting follow-up is reviewed separately and does not
+authorize the remaining release actions.
 
 ## Candidate boundary
 
 - Release version: `0.9.0`
 - Base `main`: `690557d949309cf4f4234554888bb5421c49aede`
 - Review PR: [#100](https://github.com/songlab-cal/gpn/pull/100)
+- Modernization merge: `ebb3df3548fc8f364c339f0e5ddad86330c1f949`
+- Reviewed modernization tree: `aebc93d290f5d202511827be724cec70acefe07a`
 - Maintained package: `src/gpn`
 - Historical analysis: removed from `main`; local annotated archive tag prepared,
   but publication remains approval-gated
@@ -65,12 +68,13 @@ contains this review packet and cannot contain its own stable hash.
 
 [`../external-mutations.json`](../external-mutations.json) is authoritative. Only
 entries marked `approval_ready` may be included in the final maintainer decision.
-Entries marked `deferred` remain unauthorized and require separate future review.
-Before asking for approval, the PR body must state:
+Entries marked `deferred`, if any, remain unauthorized and require separate
+future review. Before asking for approval for the remaining actions, the review
+surface must state:
 
-1. its exact head commit and tree;
+1. the exact current `main` commit and tree;
 2. the exact `approval_ready` action IDs requested; and
-3. that every `deferred` action is excluded.
+3. that every deferred action is excluded.
 
 Squash merging creates a new commit ID. After merging the single PR, verify that
 the resulting `main` tree equals the approved tree, record the new `main` commit,

--- a/release/external-mutations.json
+++ b/release/external-mutations.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./external-mutations.schema.json",
   "schema_version": 1,
-  "recorded_at": "2026-08-19",
+  "recorded_at": "2026-08-25",
   "repository": "songlab-cal/gpn",
   "applied": [
     {
@@ -65,33 +65,36 @@
       "evidence": [
         "the 2026-08-19 repository API audit returned true"
       ]
-    }
-  ],
-  "pending": [
+    },
     {
       "id": "merge-modernization-pr",
       "system": "github",
-      "authorization": "explicit_final_maintainer_approval",
-      "disposition": "approval_ready",
-      "operation": "squash-merge the single approved modernization pull request",
+      "operation": "squash-merged the approved modernization pull request",
       "targets": [
-        "songlab-cal/gpn:main",
-        "songlab-cal/gpn#100"
+        "https://github.com/songlab-cal/gpn/pull/100",
+        "songlab-cal/gpn@ebb3df3548fc8f364c339f0e5ddad86330c1f949"
       ],
-      "source": "release/0.9.0/review.md",
-      "preconditions": [
-        "the body of PR 100 records the exact approved head and tree and the maintainer repeats both identifiers in the approval",
-        "all required checks pass on the exact PR head",
-        "the maintainer explicitly approves the complete diff and this ledger"
-      ],
-      "verification": [
-        "main has the same tree as the approved PR tip",
-        "PR 100 is merged without any additional code or configuration change"
-      ],
-      "failure_response": [
-        "stop at the first conflict or changed tree and return the revised complete diff for review"
+      "evidence": [
+        "the merge commit tree aebc93d290f5d202511827be724cec70acefe07a matched the reviewed PR tree",
+        "all four required GitHub Actions contexts passed on the approved head"
       ]
     },
+    {
+      "id": "publish-read-the-docs",
+      "system": "readthedocs",
+      "operation": "imported the repository and published the reviewed Sphinx site",
+      "targets": [
+        "https://app.readthedocs.org/projects/gpn/",
+        "https://gpn.readthedocs.io/en/latest/"
+      ],
+      "evidence": [
+        "Read the Docs build 34233153 succeeded for main commit ebb3df3548fc8f364c339f0e5ddad86330c1f949",
+        "the live root, model, tutorial, and citation pages returned HTTP 200",
+        "the build used the committed .readthedocs.yaml and did not execute notebooks"
+      ]
+    }
+  ],
+  "pending": [
     {
       "id": "protect-main",
       "system": "github",
@@ -200,34 +203,6 @@
       ],
       "failure_response": [
         "never overwrite artifacts or reuse the version; stop downstream writes, document the incident, yank if appropriate, and prepare a patch release"
-      ]
-    },
-    {
-      "id": "publish-read-the-docs",
-      "system": "readthedocs",
-      "authorization": "separate_future_maintainer_approval",
-      "disposition": "deferred",
-      "operation": "import the repository and publish the reviewed Sphinx site after onboarding details are fixed",
-      "targets": [
-        "songlab-cal/gpn"
-      ],
-      "source": ".readthedocs.yaml",
-      "depends_on": [
-        "publish-gpn-0-9-0"
-      ],
-      "blocked_by": [
-        "the maintainer must connect Read the Docs and select the exact public project slug"
-      ],
-      "preconditions": [
-        "the final strict offline Sphinx build passes",
-        "the exact public project slug is added to this ledger and reviewed"
-      ],
-      "verification": [
-        "the public site renders the model, demo, API, research, citation, and release pages",
-        "Read the Docs does not execute notebooks or download model/MSA assets"
-      ],
-      "failure_response": [
-        "leave repository Markdown canonical and correct previews through a pull request"
       ]
     }
   ]

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -29,3 +29,12 @@ def test_public_docs_are_attributed_to_song_lab():
 
     assert 'author = "Song Lab at UC Berkeley"' in sphinx_config
     assert "By Gonzalo Benegas" not in sphinx_config
+
+
+def test_public_documentation_links_use_read_the_docs():
+    readme = (ROOT / "README.md").read_text()
+    project = (ROOT / "pyproject.toml").read_text()
+
+    assert "https://gpn.readthedocs.io/" in readme
+    assert "github.com/songlab-cal/gpn/blob/main/docs" not in readme
+    assert 'Documentation = "https://gpn.readthedocs.io/"' in project

--- a/tests/test_release_governance.py
+++ b/tests/test_release_governance.py
@@ -34,13 +34,14 @@ def test_external_mutation_ledger_conforms_to_schema() -> None:
     deferred = [
         action for action in ledger["pending"] if action["disposition"] == "deferred"
     ]
-    assert ready and deferred
+    assert ready
     assert {action["authorization"] for action in ready} == {
         "explicit_final_maintainer_approval"
     }
-    assert {action["authorization"] for action in deferred} == {
-        "separate_future_maintainer_approval"
-    }
+    if deferred:
+        assert {action["authorization"] for action in deferred} == {
+            "separate_future_maintainer_approval"
+        }
     assert all(action["blocked_by"] for action in deferred)
 
 
@@ -50,17 +51,18 @@ def test_external_mutation_ledger_covers_release_boundary() -> None:
     applied = {action["id"]: action for action in ledger["applied"]}
 
     assert set(pending) == {
-        "merge-modernization-pr",
         "protect-main",
         "enable-security-features",
         "publish-analysis-archive",
         "publish-gpn-0-9-0",
-        "publish-read-the-docs",
     }
-    assert "pypi-trusted-publisher-binding" in applied
+    assert {
+        "pypi-trusted-publisher-binding",
+        "merge-modernization-pr",
+        "publish-read-the-docs",
+    } <= set(applied)
     assert pending["protect-main"]["source"] == "release/main-ruleset.json"
     assert pending["publish-gpn-0-9-0"]["source"] == "release/0.9.0/review.md"
-    assert pending["merge-modernization-pr"]["disposition"] == "approval_ready"
     assert pending["publish-gpn-0-9-0"]["disposition"] == "approval_ready"
 
     for action in ledger["pending"]:
@@ -88,7 +90,6 @@ def test_final_approval_has_an_exact_bounded_action_set() -> None:
     }
 
     assert ready_ids == {
-        "merge-modernization-pr",
         "protect-main",
         "enable-security-features",
         "publish-analysis-archive",
@@ -216,7 +217,7 @@ def test_release_review_uses_one_pull_request() -> None:
     ledger = _json("external-mutations.json")
     merge = next(
         action
-        for action in ledger["pending"]
+        for action in ledger["applied"]
         if action["id"] == "merge-modernization-pr"
     )
 
@@ -228,13 +229,10 @@ def test_release_review_uses_one_pull_request() -> None:
     assert "component-prs.json" not in review
     assert not (RELEASE_DIR / "0.9.0" / "component-prs.json").exists()
     assert merge["operation"] == (
-        "squash-merge the single approved modernization pull request"
+        "squash-merged the approved modernization pull request"
     )
-    assert merge["targets"] == ["songlab-cal/gpn:main", "songlab-cal/gpn#100"]
-    assert any(
-        "exact approved head and tree" in item for item in merge["preconditions"]
-    )
-    assert any("exact PR head" in item for item in merge["preconditions"])
+    assert "https://github.com/songlab-cal/gpn/pull/100" in merge["targets"]
+    assert any("matched the reviewed PR tree" in item for item in merge["evidence"])
 
     governance_text = "\n".join(
         (review, runbook, release_readme, json.dumps(ledger))


### PR DESCRIPTION
## Summary

- point the README documentation navigation, model pages, CLI guide, and package metadata to the live Read the Docs site
- add the Read the Docs build-status badge
- record the completed #100 merge and Read the Docs deployment in the external-mutation ledger
- update the release review record to reflect the verified modernization merge

## Verification

- Read the Docs build 34233153 succeeded for main commit ebb3df3548fc8f364c339f0e5ddad86330c1f949
- live root, model, tutorial, and citation pages returned HTTP 200
- 232 offline tests passed; 6 opt-in network/GPU tests skipped
- every pre-commit hook passed
- notebook preparation and strict Sphinx build passed with notebook execution disabled

Related to #82.