### PR TITLE
Release GPN 0.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   build:
     name: Build distributions
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,11 +31,11 @@ repos:
   - repo: local
     hooks:
       - id: mypy
-        name: mypy maintained typed surface
+        name: mypy full package
         entry: uv run mypy
         language: system
         pass_filenames: false
-        files: ^(pyproject\.toml|src/gpn/(_registration|scoring|training|star/checkpoint)\.py)$
+        files: ^(pyproject\.toml|src/gpn/.*\.py)$
 
       - id: deptry
         name: dependency placement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 GPN follows Semantic Versioning. Package releases are distinct from immutable
 Hugging Face model revisions.
 
-## 0.9.0 — Unreleased
+## 0.9.0 — 2026-08-25
 
 ### Added
 
@@ -13,7 +13,7 @@ Hugging Face model revisions.
 - Explicit AutoClass registration, a stable `gpn` CLI, uv-managed development,
   Ruff, package-wide mypy and jaxtyping, offline CI, and built-wheel checks.
 - A consistent family-first CLI for GPN, GPN-MSA, and GPN-Star inference.
-- Sphinx/MyST documentation prepared for Read the Docs.
+- Hosted Sphinx/MyST documentation on Read the Docs.
 - A maintainer release runbook, reviewable GitHub ruleset proposal, external-
   mutation manifest, and pull-request checklist.
 
@@ -39,8 +39,8 @@ Hugging Face model revisions.
 ### Removed
 
 - Historical paper analyses, dataset-building workflows, GPN-MSA training, and
-  retired notebooks from `main`. They remain available at the prepared
-  `analysis-archive-2026-08-18` tag, pending final publication approval.
+  retired notebooks from `main`. They remain available at the published
+  `analysis-archive-2026-08-18` tag.
 - The unsupported auxiliary-feature disabling flag, which represented an ablation
   rather than a maintained inference mode.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Hugging Face model revisions.
   supported model family and the Sorghum GPN fine-tune.
 - Canonical prepared-data training recipes for GPN and GPN-Star.
 - Explicit AutoClass registration, a stable `gpn` CLI, uv-managed development,
-  Ruff, package-wide mypy and jaxtyping, offline CI, and built-wheel checks.
+  Ruff, mypy coverage and jaxtyping, offline CI, and built-wheel checks.
 - A consistent family-first CLI for GPN, GPN-MSA, and GPN-Star inference.
 - Hosted Sphinx/MyST documentation on Read the Docs.
 - A maintainer release runbook, reviewable GitHub ruleset proposal, external-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Hugging Face model revisions.
   supported model family and the Sorghum GPN fine-tune.
 - Canonical prepared-data training recipes for GPN and GPN-Star.
 - Explicit AutoClass registration, a stable `gpn` CLI, uv-managed development,
-  Ruff, mypy coverage and jaxtyping, offline CI, and built-wheel checks.
+  package-wide Ruff linting and formatting, strict mypy and semantic jaxtyping,
+  offline CI, and built-wheel checks.
 - A consistent family-first CLI for GPN, GPN-MSA, and GPN-Star inference.
 - Hosted Sphinx/MyST documentation on Read the Docs.
 - A maintainer release runbook, reviewable GitHub ruleset proposal, external-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ dev = [
   "pre-commit>=4.2",
   "pytest>=8.3",
   "ruff>=0.16.3",
+  "types-networkx>=3.6",
   "types-pyyaml>=6.0.12.20250915",
   "twine>=6",
 ]
@@ -127,21 +128,7 @@ markers = [
 
 [tool.mypy]
 python_version = "3.13"
-files = [
-  "src/gpn/cli.py",
-  "src/gpn/_registration.py",
-  "src/gpn/arguments.py",
-  "src/gpn/checkpoint.py",
-  "src/gpn/inference.py",
-  "src/gpn/ss/data.py",
-  "src/gpn/ss/inference.py",
-  "src/gpn/msa/data.py",
-  "src/gpn/msa/inference.py",
-  "src/gpn/star/data.py",
-  "src/gpn/star/inference.py",
-  "src/gpn/scoring.py",
-  "src/gpn/training.py",
-]
+files = ["src/gpn"]
 follow_imports = "skip"
 check_untyped_defs = true
 disallow_untyped_defs = true
@@ -189,12 +176,21 @@ extend-exclude = ["*.ipynb"]
 select = ["E4", "E7", "E9", "F", "I"]
 
 [tool.ruff.lint.per-file-ignores]
-# Legacy checkpoint classes are intentionally re-exported after their replacements.
-"src/gpn/model.py" = ["E402"]
 # Pyflakes parses jaxtyping's runtime shape strings as forward annotations.
+"src/gpn/data.py" = ["F722"]
+"src/gpn/embeddings.py" = ["F722"]
+"src/gpn/losses.py" = ["F722"]
+"src/gpn/msa/inference.py" = ["F722"]
+"src/gpn/msa/model.py" = ["F722"]
 "src/gpn/phylo/model.py" = ["F722"]
 "src/gpn/scoring.py" = ["F722"]
+"src/gpn/ss/inference.py" = ["F722"]
+"src/gpn/ss/model.py" = ["F722"]
+"src/gpn/ss/modules.py" = ["F722"]
+"src/gpn/star/inference.py" = ["F722"]
+"src/gpn/star/model.py" = ["F722"]
 "src/gpn/star/train.py" = ["F722"]
+"src/gpn/star/utils.py" = ["F722"]
 
 [tool.uv]
 default-groups = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,15 +129,16 @@ markers = [
 [tool.mypy]
 python_version = "3.13"
 files = ["src/gpn"]
+strict = true
+# Type-check every repository-owned module strictly, but do not attempt to check
+# the implementations of dynamic ML/data libraries. Their public stubs are
+# incomplete and several valid Transformers extension signatures are narrower
+# than the upstream annotations permit.
 follow_imports = "skip"
-check_untyped_defs = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-no_implicit_optional = true
-strict_equality = true
-warn_redundant_casts = true
-warn_unused_configs = true
-warn_unused_ignores = true
+disallow_subclassing_any = false
+disallow_untyped_calls = false
+disallow_untyped_decorators = false
+warn_return_any = false
 show_error_codes = true
 pretty = true
 

--- a/release/0.9.0/review.md
+++ b/release/0.9.0/review.md
@@ -1,26 +1,29 @@
 # GPN 0.9.0 review packet
 
-Status: **the modernization was merged to `main`; version 0.9.0 remains
-unreleased. No release, tag, repository-setting change, or Hugging Face write is
-authorized by this file.**
+Status: **final release candidate; version 0.9.0 remains unreleased. Publishing
+the release still requires explicit approval of the exact final PR head and
+tree.**
 
 The single pull request, [#100](https://github.com/songlab-cal/gpn/pull/100), was
 the binding review surface for the complete modernization. It was squash-merged
 as `ebb3df3548fc8f364c339f0e5ddad86330c1f949`; the resulting tree
 `aebc93d290f5d202511827be724cec70acefe07a` matched the approved PR tree. The
-subsequent documentation-hosting follow-up is reviewed separately and does not
-authorize the remaining release actions.
+subsequent documentation-hosting follow-up was merged as
+`305c29a1db9bf327c7d2bc049b8800d8dc131fdb`. The final release PR is a small,
+separate review surface for the dated changelog, applied-action evidence, and
+release binding.
 
 ## Candidate boundary
 
 - Release version: `0.9.0`
-- Base `main`: `690557d949309cf4f4234554888bb5421c49aede`
+- Release-PR base `main`: `305c29a1db9bf327c7d2bc049b8800d8dc131fdb`
 - Review PR: [#100](https://github.com/songlab-cal/gpn/pull/100)
+- Final release PR: assigned after the initial candidate commit
 - Modernization merge: `ebb3df3548fc8f364c339f0e5ddad86330c1f949`
 - Reviewed modernization tree: `aebc93d290f5d202511827be724cec70acefe07a`
 - Maintained package: `src/gpn`
-- Historical analysis: removed from `main`; local annotated archive tag prepared,
-  but publication remains approval-gated
+- Historical analysis: removed from `main` and published at the immutable
+  `analysis-archive-2026-08-18` tag
 - Dataset-building workflows and GPN-MSA training: unsupported and absent
 - GPN-MSA: deprecated inference only
 - Supported inference families: GPN, GPN-MSA, PhyloGPN, and GPN-Star; supported
@@ -42,6 +45,11 @@ authorize the remaining release actions.
   model-family collection. Auditing and editing the Hub-hosted cards and
   collection descriptions are deferred to issue #81 and absent from this
   milestone.
+- The historical-versus-current PhyloGPN output discrepancy is documented in
+  issue #108. The current immutable 2026 checkpoint is reproducible through both
+  the pinned Hub implementation and maintained local implementation; determining
+  the intent of the earlier checkpoint replacement is explicitly deferred until
+  after 0.9.0 by the maintainer.
 - A one-off remote lazy-Parquet validation matched all 3,380 OMIM TraitGym rows
   with no missing variants. The joined scores produced global AUPRC
   `0.764397828826`, versus `0.764514758694` from the released
@@ -72,8 +80,8 @@ Entries marked `deferred`, if any, remain unauthorized and require separate
 future review. Before asking for approval for the remaining actions, the review
 surface must state:
 
-1. the exact current `main` commit and tree;
-2. the exact `approval_ready` action IDs requested; and
+1. the exact final release-PR head and tree;
+2. the exact `publish-gpn-0-9-0` action requested; and
 3. that every deferred action is excluded.
 
 Squash merging creates a new commit ID. After merging the single PR, verify that

--- a/release/0.9.0/review.md
+++ b/release/0.9.0/review.md
@@ -18,7 +18,7 @@ release binding.
 - Release version: `0.9.0`
 - Release-PR base `main`: `305c29a1db9bf327c7d2bc049b8800d8dc131fdb`
 - Review PR: [#100](https://github.com/songlab-cal/gpn/pull/100)
-- Final release PR: assigned after the initial candidate commit
+- Final release PR: [#110](https://github.com/songlab-cal/gpn/pull/110)
 - Modernization merge: `ebb3df3548fc8f364c339f0e5ddad86330c1f949`
 - Reviewed modernization tree: `aebc93d290f5d202511827be724cec70acefe07a`
 - Maintained package: `src/gpn`

--- a/release/0.9.0/review.md
+++ b/release/0.9.0/review.md
@@ -43,8 +43,8 @@ release binding.
   commit-pinned; institutional filesystem paths were not committed as supported
   configuration. The repository documentation inventories the assets in each
   model-family collection. Auditing and editing the Hub-hosted cards and
-  collection descriptions are deferred to issue #81 and absent from this
-  milestone.
+  collection descriptions are deferred to post-release issue #81 and are
+  intentionally outside this release candidate.
 - The historical-versus-current PhyloGPN output discrepancy is documented in
   issue #108. The current immutable 2026 checkpoint is reproducible through both
   the pinned Hub implementation and maintained local implementation; determining

--- a/release/analysis-archive.md
+++ b/release/analysis-archive.md
@@ -6,9 +6,10 @@ operation, not the supported package.
 
 The historical research tree is preserved at commit
 `30dee6cf45849dfdcfc043ca8baf44fd6ba51d74` by the annotated tag
-`analysis-archive-2026-08-18`. The tag exists locally in the modernization candidate
-but must not be pushed or published as a GitHub release until final maintainer
-approval.
+`analysis-archive-2026-08-18`. The exact tag object
+`312a6c70de6700e729bcea4c9a67ab42a72f05f7` and its lightweight
+[GitHub Release](https://github.com/songlab-cal/gpn/releases/tag/analysis-archive-2026-08-18)
+were published and verified on 2026-08-25.
 
 ## Snapshot manifest
 
@@ -49,7 +50,7 @@ assets, and historical environments. Maintained replacements are the GPN and
 GPN-Star prepared-data recipes, published-model fixtures, and the supported
 model inference code. GPN-MSA training is intentionally not maintained.
 
-## Proposed GitHub release
+## Published GitHub release
 
 Title: `Historical GPN analysis archive (2026-08-18)`
 

--- a/release/analysis-archive.md
+++ b/release/analysis-archive.md
@@ -37,7 +37,7 @@ The `analysis/` count consists of 30 Brassicales files, 15 animal-promoter files
 60 GPN-MSA files, 83 GPN-Star files, 19 Sorghum-expression files, and the archive
 README.
 
-After the tag is published, inspect or check out the snapshot with:
+Inspect or check out the published snapshot with:
 
 ```bash
 git show analysis-archive-2026-08-18:analysis/ARCHIVE.md

--- a/release/external-mutations.json
+++ b/release/external-mutations.json
@@ -92,88 +92,50 @@
         "the live root, model, tutorial, and citation pages returned HTTP 200",
         "the build used the committed .readthedocs.yaml and did not execute notebooks"
       ]
-    }
-  ],
-  "pending": [
+    },
     {
       "id": "protect-main",
       "system": "github",
-      "authorization": "explicit_final_maintainer_approval",
-      "disposition": "approval_ready",
-      "operation": "create the active repository ruleset after its required contexts exist on main",
+      "operation": "created the active Protect main repository ruleset",
       "targets": [
-        "songlab-cal/gpn:ruleset:Protect main"
+        "songlab-cal/gpn:ruleset:21510261"
       ],
-      "source": "release/main-ruleset.json",
-      "depends_on": [
-        "merge-modernization-pr"
-      ],
-      "preconditions": [
-        "the final CI workflow has reported all four required contexts named in release/main-ruleset.json on a pull request",
-        "squash merging remains enabled",
-        "no approval count or CODEOWNERS rule is added while there is one active maintainer"
-      ],
-      "verification": [
-        "the ruleset targets only the default branch and has no bypass actors",
-        "a direct push, force push, and branch deletion are blocked",
-        "a green up-to-date PR with resolved conversations can be squash-merged by the maintainer"
-      ],
-      "failure_response": [
-        "disable the ruleset through repository administration, record the reason, correct the payload through review, and re-enable it"
+      "evidence": [
+        "the active ruleset targets only the default branch and requires the four GitHub Actions contexts",
+        "squash is the only merge method; zero approvals are required; resolved conversations are required",
+        "require_extra_approval_for_unattributed_changes is explicitly false"
       ]
     },
     {
       "id": "enable-security-features",
       "system": "github",
-      "authorization": "explicit_final_maintainer_approval",
-      "disposition": "approval_ready",
-      "operation": "enable Dependabot security updates, secret scanning, secret-scanning validity checks, and push protection",
+      "operation": "enabled the reviewed repository security features",
       "targets": [
         "songlab-cal/gpn:security-and-analysis"
       ],
-      "source": "release/governance-audit-2026-08-19.md",
-      "depends_on": [
-        "merge-modernization-pr"
-      ],
-      "preconditions": [
-        "the merged tree removes the historical vulnerable manifest and pins the validated Transformers 5.15.0 runtime",
-        "the repository plan supports the selected public-repository security features"
-      ],
-      "verification": [
-        "the repository API reports each available feature enabled",
-        "the three historical Transformers alerts close without manual dismissal"
-      ],
-      "failure_response": [
-        "leave unavailable features documented and do not assume partial enablement"
+      "evidence": [
+        "Dependabot security updates are enabled",
+        "secret scanning, non-provider patterns, validity checks, and push protection are enabled",
+        "the repository API returned no open Dependabot alerts after the historical manifest left main"
       ]
     },
     {
       "id": "publish-analysis-archive",
       "system": "github",
-      "authorization": "explicit_final_maintainer_approval",
-      "disposition": "approval_ready",
-      "operation": "push the annotated historical archive tag and publish its lightweight GitHub Release",
+      "operation": "published the annotated historical archive tag and lightweight GitHub Release",
       "targets": [
-        "songlab-cal/gpn@analysis-archive-2026-08-18",
+        "https://github.com/songlab-cal/gpn/releases/tag/analysis-archive-2026-08-18",
         "tag object 312a6c70de6700e729bcea4c9a67ab42a72f05f7",
         "commit 30dee6cf45849dfdcfc043ca8baf44fd6ba51d74"
       ],
-      "source": "release/analysis-archive.md",
-      "depends_on": [
-        "merge-modernization-pr"
-      ],
-      "preconditions": [
-        "the archive manifest, annotated tag object 312a6c70de6700e729bcea4c9a67ab42a72f05f7, and peeled commit match the reviewed removal boundary",
-        "the release text states that the archived code is historical and unsupported"
-      ],
-      "verification": [
-        "the remote ref is object type tag with object ID 312a6c70de6700e729bcea4c9a67ab42a72f05f7 and peels to 30dee6cf45849dfdcfc043ca8baf44fd6ba51d74",
-        "the GitHub Release links the maintained replacement recipes and documentation"
-      ],
-      "failure_response": [
-        "do not rewrite a published archive tag; stop and request review before any corrective tag"
+      "evidence": [
+        "the remote ref is an annotated tag with object ID 312a6c70de6700e729bcea4c9a67ab42a72f05f7",
+        "the tag peels to commit 30dee6cf45849dfdcfc043ca8baf44fd6ba51d74",
+        "the public release states that the archived code is historical and unsupported"
       ]
-    },
+    }
+  ],
+  "pending": [
     {
       "id": "publish-gpn-0-9-0",
       "system": "github",
@@ -191,8 +153,8 @@
         "publish-analysis-archive"
       ],
       "preconditions": [
-        "the body of PR 100 records the exact approved tree and the maintainer repeats it in the approval",
-        "the resulting main commit is recorded after squash-merging PR 100 and has exactly the approved tree",
+        "the final release PR body records the exact approved head and tree and the maintainer approves that candidate",
+        "the resulting main commit is recorded after squash-merging the final release PR and has exactly the approved tree",
         "the package version is exactly 0.9.0 and the tag target is the approved main commit",
         "the final review packet records a clean Python 3.13 install plus wheel and sdist hashes",
         "the release workflow and pypi environment are unchanged from the reviewed versions"

--- a/release/external-mutations.json
+++ b/release/external-mutations.json
@@ -109,13 +109,15 @@
     {
       "id": "enable-security-features",
       "system": "github",
-      "operation": "enabled the reviewed repository security features",
+      "operation": "enabled the reviewed repository security features and private vulnerability reporting",
       "targets": [
-        "songlab-cal/gpn:security-and-analysis"
+        "songlab-cal/gpn:security-and-analysis",
+        "songlab-cal/gpn:private-vulnerability-reporting"
       ],
       "evidence": [
         "Dependabot security updates are enabled",
         "secret scanning, non-provider patterns, validity checks, and push protection are enabled",
+        "private vulnerability reporting is enabled",
         "the repository API returned no open Dependabot alerts after the historical manifest left main"
       ]
     },

--- a/release/main-ruleset.json
+++ b/release/main-ruleset.json
@@ -26,6 +26,7 @@
         ],
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
+        "require_extra_approval_for_unattributed_changes": false,
         "require_last_push_approval": false,
         "required_approving_review_count": 0,
         "required_review_thread_resolution": true

--- a/src/gpn/data.py
+++ b/src/gpn/data.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 from datasets import Dataset, load_dataset
+from jaxtyping import UInt8
 
 
 def load_table(path: str) -> pd.DataFrame:
@@ -71,7 +72,9 @@ class Tokenizer:
 
     def __init__(self, vocab: str = "-ACGT?"):
         unknown = vocab.index("-")
-        self.table = np.full((256,), unknown, dtype=np.uint8)
+        self.table: UInt8[np.ndarray, "... byte"] = np.full(
+            (256,), unknown, dtype=np.uint8
+        )
         for index, character in enumerate(vocab):
             self.table[ord(character)] = index
         self.vocab = vocab
@@ -114,7 +117,7 @@ class ReverseComplementer:
             b"c": b"g",
             b"g": b"c",
         }
-        self.table = np.array(
+        self.table: np.ndarray = np.array(
             [
                 complement_mapping.get(chr(index).encode(), chr(index).encode())
                 for index in range(256)
@@ -136,7 +139,7 @@ def slice_alignment(
 
     if end <= start:
         raise ValueError("Alignment interval end must be greater than start")
-    result = np.full((end - start, n_species), b"-", dtype="|S1")
+    result: np.ndarray = np.full((end - start, n_species), b"-", dtype="|S1")
     source_start = max(start, 0)
     source_stop = min(end, array.shape[0])
     if source_start < source_stop:

--- a/src/gpn/embeddings.py
+++ b/src/gpn/embeddings.py
@@ -1,19 +1,37 @@
 """Embedding layers shared by GPN-SS and GPN-MSA."""
 
+from typing import Protocol
+
 import torch.nn as nn
 import torch.nn.functional as F
+from jaxtyping import Float, Int
+from torch import Tensor
+
+
+class AuxEmbeddingConfig(Protocol):
+    """Configuration fields consumed by :class:`OneHotAuxEmbedding`."""
+
+    vocab_size: int
+    aux_features_vocab_size: int | None
+    n_aux_features: int
+    hidden_size: int
 
 
 class OneHotAuxEmbedding(nn.Module):
     """Embed nucleotide tokens and optional auxiliary features without weights."""
 
-    def __init__(self, config):
+    def __init__(self, config: AuxEmbeddingConfig) -> None:
         super().__init__()
         self.config = config
-        self.word_embeddings = None
+        self.word_embeddings: nn.Embedding | None = None
         assert config.vocab_size + config.n_aux_features <= config.hidden_size
 
-    def forward(self, input_ids=None, input_probs=None, aux_features=None):
+    def forward(
+        self,
+        input_ids: Int[Tensor, "... position"] | None = None,
+        input_probs: Float[Tensor, "... position nucleotide"] | None = None,
+        aux_features: Tensor | None = None,
+    ) -> Float[Tensor, "... position hidden"]:
         if input_ids is not None:
             result = F.one_hot(input_ids, num_classes=self.config.hidden_size).float()
         elif input_probs is not None:

--- a/src/gpn/embeddings.py
+++ b/src/gpn/embeddings.py
@@ -4,7 +4,7 @@ from typing import Protocol
 
 import torch.nn as nn
 import torch.nn.functional as F
-from jaxtyping import Float, Int
+from jaxtyping import Float, Int, Num
 from torch import Tensor
 
 
@@ -30,7 +30,7 @@ class OneHotAuxEmbedding(nn.Module):
         self,
         input_ids: Int[Tensor, "... position"] | None = None,
         input_probs: Float[Tensor, "... position nucleotide"] | None = None,
-        aux_features: Int[Tensor, "... position auxiliary"] | None = None,
+        aux_features: Num[Tensor, "... position auxiliary"] | None = None,
     ) -> Float[Tensor, "... position hidden"]:
         if input_ids is not None:
             result = F.one_hot(input_ids, num_classes=self.config.hidden_size).float()

--- a/src/gpn/embeddings.py
+++ b/src/gpn/embeddings.py
@@ -30,7 +30,7 @@ class OneHotAuxEmbedding(nn.Module):
         self,
         input_ids: Int[Tensor, "... position"] | None = None,
         input_probs: Float[Tensor, "... position nucleotide"] | None = None,
-        aux_features: Tensor | None = None,
+        aux_features: Int[Tensor, "... position auxiliary"] | None = None,
     ) -> Float[Tensor, "... position hidden"]:
         if input_ids is not None:
             result = F.one_hot(input_ids, num_classes=self.config.hidden_size).float()

--- a/src/gpn/losses.py
+++ b/src/gpn/losses.py
@@ -1,9 +1,17 @@
 """Loss functions shared by GPN-SS and GPN-MSA."""
 
+from jaxtyping import Float, Int
+from torch import Tensor
 from torch.nn import CrossEntropyLoss
 
 
-def masked_lm_loss(logits, labels, output_probs, loss_weight, vocab_size):
+def masked_lm_loss(
+    logits: Float[Tensor, "... vocabulary"],
+    labels: Int[Tensor, "..."] | None,
+    output_probs: Float[Tensor, "... vocabulary"] | None,
+    loss_weight: Float[Tensor, "..."] | None,
+    vocab_size: int,
+) -> Float[Tensor, ""] | None:
     """Compute hard-label or soft-label masked language-model loss."""
 
     loss = None
@@ -18,6 +26,8 @@ def masked_lm_loss(logits, labels, output_probs, loss_weight, vocab_size):
         loss_weight[labels == -100] = 0.0
         loss = (loss * loss_weight / loss_weight.sum()).sum()
     elif output_probs is not None:
+        if loss_weight is None:
+            raise ValueError("loss_weight is required with soft output probabilities")
         loss_fct = CrossEntropyLoss(reduction="none")
         output_probs = output_probs.view(-1, vocab_size)
         exclude = (output_probs == 0.0).all(dim=-1)

--- a/src/gpn/msa/inference.py
+++ b/src/gpn/msa/inference.py
@@ -9,6 +9,8 @@ import numpy as np
 import pandas as pd
 import torch
 from datasets import Dataset, disable_caching
+from jaxtyping import Float, Int
+from torch import Tensor
 from transformers import AutoModel, AutoModelForMaskedLM, TrainingArguments
 
 from gpn import register_auto_classes
@@ -40,12 +42,12 @@ class MLMforVEPModel(torch.nn.Module):
 
     def get_llr(
         self,
-        input_ids: torch.Tensor,
-        aux_features: torch.Tensor,
-        pos: torch.Tensor,
-        ref: torch.Tensor,
-        alt: torch.Tensor,
-    ) -> torch.Tensor:
+        input_ids: Int[Tensor, "batch position"],
+        aux_features: Tensor,
+        pos: Int[Tensor, "... batch"],
+        ref: Int[Tensor, "... batch"],
+        alt: Int[Tensor, "... batch"],
+    ) -> Float[Tensor, "... batch"]:
         logits = self.model(input_ids=input_ids, aux_features=aux_features).logits
         logits = logits[torch.arange(len(pos), device=pos.device), pos]
         row = torch.arange(len(ref), device=ref.device)
@@ -53,17 +55,17 @@ class MLMforVEPModel(torch.nn.Module):
 
     def forward(
         self,
-        input_ids_fwd: torch.Tensor | None = None,
-        aux_features_fwd: torch.Tensor | None = None,
-        pos_fwd: torch.Tensor | None = None,
-        ref_fwd: torch.Tensor | None = None,
-        alt_fwd: torch.Tensor | None = None,
-        input_ids_rev: torch.Tensor | None = None,
-        aux_features_rev: torch.Tensor | None = None,
-        pos_rev: torch.Tensor | None = None,
-        ref_rev: torch.Tensor | None = None,
-        alt_rev: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        input_ids_fwd: Int[Tensor, "batch position"] | None = None,
+        aux_features_fwd: Tensor | None = None,
+        pos_fwd: Int[Tensor, "... batch"] | None = None,
+        ref_fwd: Int[Tensor, "... batch"] | None = None,
+        alt_fwd: Int[Tensor, "... batch"] | None = None,
+        input_ids_rev: Int[Tensor, "batch position"] | None = None,
+        aux_features_rev: Tensor | None = None,
+        pos_rev: Int[Tensor, "... batch"] | None = None,
+        ref_rev: Int[Tensor, "... batch"] | None = None,
+        alt_rev: Int[Tensor, "... batch"] | None = None,
+    ) -> Float[Tensor, "... batch"]:
         llr_fwd = self.get_llr(
             input_ids_fwd, aux_features_fwd, pos_fwd, ref_fwd, alt_fwd
         )
@@ -87,22 +89,22 @@ class MLMforLogitsModel(torch.nn.Module):
 
     def get_logits(
         self,
-        input_ids: torch.Tensor,
-        aux_features: torch.Tensor,
-        pos: torch.Tensor,
-    ) -> torch.Tensor:
+        input_ids: Int[Tensor, "batch position"],
+        aux_features: Tensor,
+        pos: Int[Tensor, "... batch"],
+    ) -> Float[Tensor, "batch nucleotide"]:
         logits = self.model(input_ids=input_ids, aux_features=aux_features).logits
         return logits[torch.arange(len(pos), device=pos.device), pos]
 
     def forward(
         self,
-        input_ids_fwd: torch.Tensor | None = None,
-        aux_features_fwd: torch.Tensor | None = None,
-        pos_fwd: torch.Tensor | None = None,
-        input_ids_rev: torch.Tensor | None = None,
-        aux_features_rev: torch.Tensor | None = None,
-        pos_rev: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        input_ids_fwd: Int[Tensor, "batch position"] | None = None,
+        aux_features_fwd: Tensor | None = None,
+        pos_fwd: Int[Tensor, "... batch"] | None = None,
+        input_ids_rev: Int[Tensor, "batch position"] | None = None,
+        aux_features_rev: Tensor | None = None,
+        pos_rev: Int[Tensor, "... batch"] | None = None,
+    ) -> Float[Tensor, "batch nucleotide"]:
         a, c, g, t = self.nucleotide_ids
         logits_fwd = self.get_logits(input_ids_fwd, aux_features_fwd, pos_fwd)[
             :, [a, c, g, t]
@@ -130,9 +132,9 @@ class ModelCenterEmbedding(torch.nn.Module):
 
     def get_center_embedding(
         self,
-        input_ids: torch.Tensor,
-        aux_features: torch.Tensor,
-    ) -> torch.Tensor:
+        input_ids: Int[Tensor, "batch position"],
+        aux_features: Tensor,
+    ) -> Float[Tensor, "batch hidden"]:
         embedding = self.model(
             input_ids=input_ids, aux_features=aux_features
         ).last_hidden_state
@@ -145,11 +147,11 @@ class ModelCenterEmbedding(torch.nn.Module):
 
     def forward(
         self,
-        input_ids_fwd: torch.Tensor | None = None,
-        input_ids_rev: torch.Tensor | None = None,
-        aux_features_fwd: torch.Tensor | None = None,
-        aux_features_rev: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        input_ids_fwd: Int[Tensor, "batch position"] | None = None,
+        input_ids_rev: Int[Tensor, "batch position"] | None = None,
+        aux_features_fwd: Tensor | None = None,
+        aux_features_rev: Tensor | None = None,
+    ) -> Float[Tensor, "batch hidden"]:
         embedding_fwd = self.get_center_embedding(input_ids_fwd, aux_features_fwd)
         embedding_rev = self.get_center_embedding(input_ids_rev, aux_features_rev)
         return (embedding_fwd + embedding_rev) / 2

--- a/src/gpn/msa/inference.py
+++ b/src/gpn/msa/inference.py
@@ -43,7 +43,7 @@ class MLMforVEPModel(torch.nn.Module):
     def get_llr(
         self,
         input_ids: Int[Tensor, "batch position"],
-        aux_features: Tensor,
+        aux_features: Int[Tensor, "batch position auxiliary"],
         pos: Int[Tensor, "... batch"],
         ref: Int[Tensor, "... batch"],
         alt: Int[Tensor, "... batch"],
@@ -56,12 +56,12 @@ class MLMforVEPModel(torch.nn.Module):
     def forward(
         self,
         input_ids_fwd: Int[Tensor, "batch position"] | None = None,
-        aux_features_fwd: Tensor | None = None,
+        aux_features_fwd: Int[Tensor, "batch position auxiliary"] | None = None,
         pos_fwd: Int[Tensor, "... batch"] | None = None,
         ref_fwd: Int[Tensor, "... batch"] | None = None,
         alt_fwd: Int[Tensor, "... batch"] | None = None,
         input_ids_rev: Int[Tensor, "batch position"] | None = None,
-        aux_features_rev: Tensor | None = None,
+        aux_features_rev: Int[Tensor, "batch position auxiliary"] | None = None,
         pos_rev: Int[Tensor, "... batch"] | None = None,
         ref_rev: Int[Tensor, "... batch"] | None = None,
         alt_rev: Int[Tensor, "... batch"] | None = None,
@@ -90,7 +90,7 @@ class MLMforLogitsModel(torch.nn.Module):
     def get_logits(
         self,
         input_ids: Int[Tensor, "batch position"],
-        aux_features: Tensor,
+        aux_features: Int[Tensor, "batch position auxiliary"],
         pos: Int[Tensor, "... batch"],
     ) -> Float[Tensor, "batch nucleotide"]:
         logits = self.model(input_ids=input_ids, aux_features=aux_features).logits
@@ -99,10 +99,10 @@ class MLMforLogitsModel(torch.nn.Module):
     def forward(
         self,
         input_ids_fwd: Int[Tensor, "batch position"] | None = None,
-        aux_features_fwd: Tensor | None = None,
+        aux_features_fwd: Int[Tensor, "batch position auxiliary"] | None = None,
         pos_fwd: Int[Tensor, "... batch"] | None = None,
         input_ids_rev: Int[Tensor, "batch position"] | None = None,
-        aux_features_rev: Tensor | None = None,
+        aux_features_rev: Int[Tensor, "batch position auxiliary"] | None = None,
         pos_rev: Int[Tensor, "... batch"] | None = None,
     ) -> Float[Tensor, "batch nucleotide"]:
         a, c, g, t = self.nucleotide_ids
@@ -133,7 +133,7 @@ class ModelCenterEmbedding(torch.nn.Module):
     def get_center_embedding(
         self,
         input_ids: Int[Tensor, "batch position"],
-        aux_features: Tensor,
+        aux_features: Int[Tensor, "batch position auxiliary"],
     ) -> Float[Tensor, "batch hidden"]:
         embedding = self.model(
             input_ids=input_ids, aux_features=aux_features
@@ -149,8 +149,8 @@ class ModelCenterEmbedding(torch.nn.Module):
         self,
         input_ids_fwd: Int[Tensor, "batch position"] | None = None,
         input_ids_rev: Int[Tensor, "batch position"] | None = None,
-        aux_features_fwd: Tensor | None = None,
-        aux_features_rev: Tensor | None = None,
+        aux_features_fwd: Int[Tensor, "batch position auxiliary"] | None = None,
+        aux_features_rev: Int[Tensor, "batch position auxiliary"] | None = None,
     ) -> Float[Tensor, "batch hidden"]:
         embedding_fwd = self.get_center_embedding(input_ids_fwd, aux_features_fwd)
         embedding_rev = self.get_center_embedding(input_ids_rev, aux_features_rev)

--- a/src/gpn/msa/model.py
+++ b/src/gpn/msa/model.py
@@ -79,7 +79,7 @@ class GPNMSAModel(GPNMSAPreTrainedModel):
         self,
         input_ids: Int[Tensor, "... position"] | None = None,
         input_probs: Float[Tensor, "... position nucleotide"] | None = None,
-        aux_features: Tensor | None = None,
+        aux_features: Int[Tensor, "... position auxiliary"] | None = None,
         **kwargs: Any,
     ) -> BaseModelOutput:
         x = self.embedding(

--- a/src/gpn/msa/model.py
+++ b/src/gpn/msa/model.py
@@ -1,8 +1,12 @@
 """Deprecated GPN-MSA model definitions for inference compatibility."""
 
+from typing import Any
+
 import torch.nn as nn
+from jaxtyping import Float, Int
+from torch import Tensor
 from transformers import PreTrainedModel, RoFormerConfig
-from transformers.modeling_outputs import MaskedLMOutput
+from transformers.modeling_outputs import BaseModelOutput, MaskedLMOutput
 from transformers.models.roformer.modeling_roformer import (
     RoFormerEncoder,
     RoFormerOnlyMLMHead,
@@ -24,12 +28,12 @@ class GPNMSAConfig(RoFormerConfig):
 
     def __init__(
         self,
-        vocab_size=6,
-        aux_features_vocab_size=5,
-        n_aux_features=0,
-        group_tokens=1,
-        **kwargs,
-    ):
+        vocab_size: int = 6,
+        aux_features_vocab_size: int | None = 5,
+        n_aux_features: int = 0,
+        group_tokens: int = 1,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.vocab_size = vocab_size
         self.aux_features_vocab_size = aux_features_vocab_size
@@ -41,7 +45,7 @@ class GPNMSAPreTrainedModel(PreTrainedModel):
     config_class = GPNMSAConfig
     base_model_prefix = "model"
 
-    def _init_weights(self, module):
+    def _init_weights(self, module: nn.Module) -> None:
         if isinstance(module, nn.Linear):
             module.weight.data.normal_(mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
@@ -56,20 +60,28 @@ class GPNMSAPreTrainedModel(PreTrainedModel):
             module.bias.data.zero_()
             module.weight.data.fill_(1.0)
 
-    def _set_gradient_checkpointing(self, module, value=False):
+    def _set_gradient_checkpointing(
+        self, module: nn.Module, value: bool = False
+    ) -> None:
         if isinstance(module, RoFormerEncoder):
             module.gradient_checkpointing = value
 
 
 class GPNMSAModel(GPNMSAPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config: GPNMSAConfig) -> None:
         super().__init__(config)
         self.config = config
         self.embedding = OneHotAuxEmbedding(config)
         self.encoder = RoFormerEncoder(config)
         self.post_init()
 
-    def forward(self, input_ids=None, input_probs=None, aux_features=None, **kwargs):
+    def forward(
+        self,
+        input_ids: Int[Tensor, "... position"] | None = None,
+        input_probs: Float[Tensor, "... position nucleotide"] | None = None,
+        aux_features: Tensor | None = None,
+        **kwargs: Any,
+    ) -> BaseModelOutput:
         x = self.embedding(
             input_ids=input_ids,
             input_probs=input_probs,
@@ -85,13 +97,19 @@ class GPNMSAForMaskedLM(GPNMSAPreTrainedModel):
         "cls.predictions.decoder.bias": "cls.predictions.bias",
     }
 
-    def __init__(self, config):
+    def __init__(self, config: GPNMSAConfig) -> None:
         super().__init__(config)
         self.model = GPNMSAModel(config)
         self.cls = RoFormerOnlyMLMHead(config)
         self.post_init()
 
-    def forward(self, labels=None, output_probs=None, loss_weight=None, **kwargs):
+    def forward(
+        self,
+        labels: Int[Tensor, "..."] | None = None,
+        output_probs: Float[Tensor, "... nucleotide"] | None = None,
+        loss_weight: Float[Tensor, "..."] | None = None,
+        **kwargs: Any,
+    ) -> MaskedLMOutput:
         hidden_state = self.model(**kwargs).last_hidden_state
         logits = self.cls(hidden_state)
         loss = masked_lm_loss(

--- a/src/gpn/msa/model.py
+++ b/src/gpn/msa/model.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import torch.nn as nn
-from jaxtyping import Float, Int
+from jaxtyping import Float, Int, Num
 from torch import Tensor
 from transformers import PreTrainedModel, RoFormerConfig
 from transformers.modeling_outputs import BaseModelOutput, MaskedLMOutput
@@ -79,7 +79,7 @@ class GPNMSAModel(GPNMSAPreTrainedModel):
         self,
         input_ids: Int[Tensor, "... position"] | None = None,
         input_probs: Float[Tensor, "... position nucleotide"] | None = None,
-        aux_features: Int[Tensor, "... position auxiliary"] | None = None,
+        aux_features: Num[Tensor, "... position auxiliary"] | None = None,
         **kwargs: Any,
     ) -> BaseModelOutput:
         x = self.embedding(

--- a/src/gpn/phylo/model.py
+++ b/src/gpn/phylo/model.py
@@ -149,7 +149,7 @@ class _InvariantBias(nn.Module):
         self._index_tensor: Tensor | None = None
         self._device: torch.device | None = None
 
-    def forward(self, bias: Float[Tensor, " output"]) -> Tensor:
+    def forward(self, bias: Float[Tensor, "... output"]) -> Tensor:
         if self._device != bias.device:
             self._index_tensor = torch.tensor(self._indices, device=bias.device)
             self._device = bias.device

--- a/src/gpn/ss/inference.py
+++ b/src/gpn/ss/inference.py
@@ -10,6 +10,8 @@ import pandas as pd
 import torch
 from Bio.Seq import Seq
 from datasets import Dataset, disable_caching
+from jaxtyping import Float, Int
+from torch import Tensor
 from transformers import (
     AutoModel,
     AutoModelForMaskedLM,
@@ -66,11 +68,11 @@ class MLMforVEPModel(torch.nn.Module):
 
     def get_llr(
         self,
-        input_ids: torch.Tensor,
-        pos: torch.Tensor,
-        ref: torch.Tensor,
-        alt: torch.Tensor,
-    ) -> torch.Tensor:
+        input_ids: Int[Tensor, "batch position"],
+        pos: Int[Tensor, "... batch"],
+        ref: Int[Tensor, "... batch"],
+        alt: Int[Tensor, "... batch"],
+    ) -> Float[Tensor, "... batch"]:
         logits = self.model(input_ids=input_ids).logits
         logits = logits[torch.arange(len(pos), device=pos.device), pos]
         row = torch.arange(len(ref), device=ref.device)
@@ -78,15 +80,15 @@ class MLMforVEPModel(torch.nn.Module):
 
     def forward(
         self,
-        input_ids_fwd: torch.Tensor | None = None,
-        pos_fwd: torch.Tensor | None = None,
-        ref_fwd: torch.Tensor | None = None,
-        alt_fwd: torch.Tensor | None = None,
-        input_ids_rev: torch.Tensor | None = None,
-        pos_rev: torch.Tensor | None = None,
-        ref_rev: torch.Tensor | None = None,
-        alt_rev: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        input_ids_fwd: Int[Tensor, "batch position"] | None = None,
+        pos_fwd: Int[Tensor, "... batch"] | None = None,
+        ref_fwd: Int[Tensor, "... batch"] | None = None,
+        alt_fwd: Int[Tensor, "... batch"] | None = None,
+        input_ids_rev: Int[Tensor, "batch position"] | None = None,
+        pos_rev: Int[Tensor, "... batch"] | None = None,
+        ref_rev: Int[Tensor, "... batch"] | None = None,
+        alt_rev: Int[Tensor, "... batch"] | None = None,
+    ) -> Float[Tensor, "... batch"]:
         llr_fwd = self.get_llr(input_ids_fwd, pos_fwd, ref_fwd, alt_fwd)
         llr_rev = self.get_llr(input_ids_rev, pos_rev, ref_rev, alt_rev)
         return (llr_fwd + llr_rev) / 2
@@ -112,19 +114,19 @@ class MLMforLogitsModel(torch.nn.Module):
 
     def get_logits(
         self,
-        input_ids: torch.Tensor,
-        pos: torch.Tensor,
-    ) -> torch.Tensor:
+        input_ids: Int[Tensor, "batch position"],
+        pos: Int[Tensor, "... batch"],
+    ) -> Float[Tensor, "batch nucleotide"]:
         logits = self.model(input_ids=input_ids).logits
         return logits[torch.arange(len(pos), device=pos.device), pos]
 
     def forward(
         self,
-        input_ids_fwd: torch.Tensor | None = None,
-        pos_fwd: torch.Tensor | None = None,
-        input_ids_rev: torch.Tensor | None = None,
-        pos_rev: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        input_ids_fwd: Int[Tensor, "batch position"] | None = None,
+        pos_fwd: Int[Tensor, "... batch"] | None = None,
+        input_ids_rev: Int[Tensor, "batch position"] | None = None,
+        pos_rev: Int[Tensor, "... batch"] | None = None,
+    ) -> Float[Tensor, "batch nucleotide"]:
         a, c, g, t = self.nucleotide_ids
         logits_fwd = self.get_logits(input_ids_fwd, pos_fwd)[:, [a, c, g, t]]
         logits_rev = self.get_logits(input_ids_rev, pos_rev)[:, [t, g, c, a]]
@@ -148,7 +150,9 @@ class ModelCenterEmbedding(torch.nn.Module):
         self.model.eval()
         self.center_window_size = center_window_size
 
-    def get_center_embedding(self, input_ids: torch.Tensor) -> torch.Tensor:
+    def get_center_embedding(
+        self, input_ids: Int[Tensor, "batch position"]
+    ) -> Float[Tensor, "batch hidden"]:
         embedding = self.model(input_ids=input_ids).last_hidden_state
         center = embedding.shape[1] // 2
         left = center - self.center_window_size // 2
@@ -159,9 +163,9 @@ class ModelCenterEmbedding(torch.nn.Module):
 
     def forward(
         self,
-        input_ids_fwd: torch.Tensor | None = None,
-        input_ids_rev: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        input_ids_fwd: Int[Tensor, "batch position"] | None = None,
+        input_ids_rev: Int[Tensor, "batch position"] | None = None,
+    ) -> Float[Tensor, "batch hidden"]:
         embedding_fwd = self.get_center_embedding(input_ids_fwd)
         embedding_rev = self.get_center_embedding(input_ids_rev)
         return (embedding_fwd + embedding_rev) / 2

--- a/src/gpn/ss/model.py
+++ b/src/gpn/ss/model.py
@@ -5,7 +5,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from jaxtyping import Float, Int
+from jaxtyping import Float, Int, Num
 from torch import Tensor
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 from transformers import (
@@ -327,7 +327,7 @@ class GPNModel(GPNPreTrainedModel):
         self,
         input_ids: Int[Tensor, "... position"] | None = None,
         input_probs: Float[Tensor, "... position nucleotide"] | None = None,
-        aux_features: Int[Tensor, "... position auxiliary"] | None = None,
+        aux_features: Num[Tensor, "... position auxiliary"] | None = None,
         **kwargs: Any,
     ) -> BaseModelOutput:
         x = self.embeddings(
@@ -405,7 +405,7 @@ class GPNForSequenceClassification(GPNPreTrainedModel):
     def forward(
         self,
         input_ids: Int[Tensor, "batch position"] | None = None,
-        aux_features: Int[Tensor, "batch position auxiliary"] | None = None,
+        aux_features: Num[Tensor, "batch position auxiliary"] | None = None,
         labels: Tensor | None = None,
     ) -> SequenceClassifierOutput:
         r"""
@@ -475,7 +475,7 @@ class GPNForTokenClassification(GPNPreTrainedModel):
     def forward(
         self,
         input_ids: Int[Tensor, "batch position"] | None = None,
-        aux_features: Int[Tensor, "batch position auxiliary"] | None = None,
+        aux_features: Num[Tensor, "batch position auxiliary"] | None = None,
         labels: Tensor | None = None,
     ) -> TokenClassifierOutput:
         x = self.model(input_ids=input_ids, aux_features=aux_features).last_hidden_state
@@ -661,7 +661,7 @@ class ConvNetModel(ConvNetPreTrainedModel):
         self,
         input_ids: Int[Tensor, "... position"] | None = None,
         input_probs: Float[Tensor, "... position nucleotide"] | None = None,
-        aux_features: Int[Tensor, "... position auxiliary"] | None = None,
+        aux_features: Num[Tensor, "... position auxiliary"] | None = None,
         **kwargs: Any,
     ) -> BaseModelOutput:
         x = self.embedding(

--- a/src/gpn/ss/model.py
+++ b/src/gpn/ss/model.py
@@ -327,7 +327,7 @@ class GPNModel(GPNPreTrainedModel):
         self,
         input_ids: Int[Tensor, "... position"] | None = None,
         input_probs: Float[Tensor, "... position nucleotide"] | None = None,
-        aux_features: Tensor | None = None,
+        aux_features: Int[Tensor, "... position auxiliary"] | None = None,
         **kwargs: Any,
     ) -> BaseModelOutput:
         x = self.embeddings(
@@ -405,7 +405,7 @@ class GPNForSequenceClassification(GPNPreTrainedModel):
     def forward(
         self,
         input_ids: Int[Tensor, "batch position"] | None = None,
-        aux_features: Tensor | None = None,
+        aux_features: Int[Tensor, "batch position auxiliary"] | None = None,
         labels: Tensor | None = None,
     ) -> SequenceClassifierOutput:
         r"""
@@ -475,7 +475,7 @@ class GPNForTokenClassification(GPNPreTrainedModel):
     def forward(
         self,
         input_ids: Int[Tensor, "batch position"] | None = None,
-        aux_features: Tensor | None = None,
+        aux_features: Int[Tensor, "batch position auxiliary"] | None = None,
         labels: Tensor | None = None,
     ) -> TokenClassifierOutput:
         x = self.model(input_ids=input_ids, aux_features=aux_features).last_hidden_state
@@ -661,7 +661,7 @@ class ConvNetModel(ConvNetPreTrainedModel):
         self,
         input_ids: Int[Tensor, "... position"] | None = None,
         input_probs: Float[Tensor, "... position nucleotide"] | None = None,
-        aux_features: Tensor | None = None,
+        aux_features: Int[Tensor, "... position auxiliary"] | None = None,
         **kwargs: Any,
     ) -> BaseModelOutput:
         x = self.embedding(

--- a/src/gpn/ss/model.py
+++ b/src/gpn/ss/model.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from jaxtyping import Float, Int
 from torch import Tensor
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 from transformers import (
@@ -24,7 +29,9 @@ from ..embeddings import OneHotAuxEmbedding
 from ..losses import masked_lm_loss
 from .modules import CNN, MLP, ByteNetEncoder, ConvNetEncoder
 
-ENCODER_CLASS = {
+ENCODER_CLASS: dict[
+    str, type[ByteNetEncoder] | type[ConvNetEncoder] | type[RoFormerEncoder]
+] = {
     "bytenet": ByteNetEncoder,
     "convnet": ConvNetEncoder,
     "roformer": RoFormerEncoder,
@@ -37,17 +44,21 @@ class TransposeLinear(nn.Linear):
 
 
 class GPNEmbedding2(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNConfig) -> None:
         super().__init__()
         self.word_embeddings = nn.Embedding(
             config.vocab_size, config.hidden_size, padding_idx=0
         )
 
-    def forward(self, input_ids, **kwargs):
+    def forward(
+        self,
+        input_ids: Int[Tensor, "... position"],
+        **kwargs: Any,
+    ) -> Float[Tensor, "... position hidden"]:
         return self.word_embeddings(input_ids)
 
 
-EMBEDDING_CLASS = {
+EMBEDDING_CLASS: dict[str, type[OneHotAuxEmbedding] | type[GPNEmbedding2]] = {
     "one_hot": OneHotAuxEmbedding,
     "embedding": GPNEmbedding2,
 }
@@ -56,8 +67,8 @@ EMBEDDING_CLASS = {
 class MLMHead(nn.Module):
     def __init__(
         self,
-        config,
-    ):
+        config: GPNConfig,
+    ) -> None:
         super().__init__()
         self.config = config
         if config.mlm_head_transform:
@@ -72,7 +83,9 @@ class MLMHead(nn.Module):
             config.hidden_size, config.vocab_size, bias=config.bias
         )
 
-    def forward(self, hidden_states):
+    def forward(
+        self, hidden_states: Float[Tensor, "... position hidden"]
+    ) -> Float[Tensor, "... position nucleotide"]:
         hidden_states = self.transform(hidden_states)
         hidden_states = self.decoder(hidden_states)
         return hidden_states
@@ -81,7 +94,7 @@ class MLMHead(nn.Module):
 class StandardClassificationHead(nn.Module):
     """Head for sentence-level classification tasks."""
 
-    def __init__(self, config):
+    def __init__(self, config: GPNConfig) -> None:
         super().__init__()
         self.ln = nn.LayerNorm(config.hidden_size, bias=config.bias)
         self.dense = nn.Linear(config.hidden_size, config.hidden_size, bias=config.bias)
@@ -92,7 +105,11 @@ class StandardClassificationHead(nn.Module):
 
         self.config = config
 
-    def forward(self, features, **kwargs):
+    def forward(
+        self,
+        features: Float[Tensor, "batch position hidden"],
+        **kwargs: Any,
+    ) -> Float[Tensor, "batch label"]:
         x = features.mean(axis=1)  # mean pooling
         x = self.ln(x)
         x = self.dropout(x)
@@ -106,7 +123,7 @@ class StandardClassificationHead(nn.Module):
 class LightweightCNNClassificationHead(nn.Module):
     """Head for sentence-level classification tasks."""
 
-    def __init__(self, config):
+    def __init__(self, config: GPNConfig) -> None:
         super().__init__()
         intermediate_size = 64
         kernel_size = 3
@@ -130,7 +147,11 @@ class LightweightCNNClassificationHead(nn.Module):
         self.ln = nn.LayerNorm(intermediate_size, bias=False)
         self.final = nn.Linear(intermediate_size, config.num_labels, bias=False)
 
-    def forward(self, x, **kwargs):
+    def forward(
+        self,
+        x: Float[Tensor, "batch position hidden"],
+        **kwargs: Any,
+    ) -> Float[Tensor, "batch label"]:
         x = self.conv1(x)
         x = self.conv2(x)
         x = x.mean(axis=1)
@@ -143,7 +164,7 @@ class LightweightCNNClassificationHead(nn.Module):
 class LightweightMLPClassificationHead(nn.Module):
     """Head for sentence-level classification tasks."""
 
-    def __init__(self, config):
+    def __init__(self, config: GPNConfig) -> None:
         super().__init__()
         intermediate_size = 64
         self.mlp1 = MLP(
@@ -159,7 +180,11 @@ class LightweightMLPClassificationHead(nn.Module):
         self.ln = nn.LayerNorm(intermediate_size, bias=False)
         self.final = nn.Linear(intermediate_size, config.num_labels, bias=False)
 
-    def forward(self, x, **kwargs):
+    def forward(
+        self,
+        x: Float[Tensor, "batch position hidden"],
+        **kwargs: Any,
+    ) -> Float[Tensor, "batch label"]:
         x = self.mlp1(x)
         x = x.mean(axis=1)
         x = self.mlp2(x)
@@ -168,7 +193,12 @@ class LightweightMLPClassificationHead(nn.Module):
         return x
 
 
-CLASSIFICATION_HEAD_CLASS = {
+CLASSIFICATION_HEAD_CLASS: dict[
+    str,
+    type[StandardClassificationHead]
+    | type[LightweightMLPClassificationHead]
+    | type[LightweightCNNClassificationHead],
+] = {
     "standard": StandardClassificationHead,
     "lightweight_mlp": LightweightMLPClassificationHead,
     "lightweight_cnn": LightweightCNNClassificationHead,
@@ -180,34 +210,34 @@ class GPNConfig(RoFormerConfig):
 
     def __init__(
         self,
-        vocab_size=7,  # ss: 7, msa: 6
-        aux_features_vocab_size=5,
-        n_aux_features=0,
-        embedding="one_hot",  # one_hot, embedding
-        encoder="convnet",  # convnet, roformer, bytenet
-        num_hidden_layers=25,  # roformer: 12
-        hidden_size=512,  # roformer: 768
-        intermediate_size=2048,  # roformer: 3072 (usually 4 * hidden_size)
-        hidden_dropout_prob=0.0,
-        bias=False,
-        tie_word_embeddings=False,
-        mlm_head_transform=True,
+        vocab_size: int = 7,  # ss: 7, msa: 6
+        aux_features_vocab_size: int | None = 5,
+        n_aux_features: int = 0,
+        embedding: str = "one_hot",  # one_hot, embedding
+        encoder: str = "convnet",  # convnet, roformer, bytenet
+        num_hidden_layers: int = 25,  # roformer: 12
+        hidden_size: int = 512,  # roformer: 768
+        intermediate_size: int = 2048,  # roformer: 3072
+        hidden_dropout_prob: float = 0.0,
+        bias: bool = False,
+        tie_word_embeddings: bool = False,
+        mlm_head_transform: bool = True,
         # bytenet-specific
-        slim=False,
+        slim: bool = False,
         # convnet-specific
-        first_kernel_size=9,
-        rest_kernel_size=5,
-        dilation_double_every=1,
-        dilation_max=9999,
-        dilation_cycle=8,
-        dilation_base=2,
-        depthwise=False,
+        first_kernel_size: int = 9,
+        rest_kernel_size: int = 5,
+        dilation_double_every: int = 1,
+        dilation_max: int = 9999,
+        dilation_cycle: int = 8,
+        dilation_base: int = 2,
+        depthwise: bool = False,
         # specific to head for downstream classification/regression task
-        classification_head="standard",
-        pos_weight=None,
-        regression_softplus=False,
-        **kwargs,
-    ):
+        classification_head: str = "standard",
+        pos_weight: float | list[float] | None = None,
+        regression_softplus: bool = False,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.vocab_size = vocab_size
         self.aux_features_vocab_size = aux_features_vocab_size
@@ -240,7 +270,7 @@ class GPNPreTrainedModel(PreTrainedModel):
     # GB: won't try to support this for now
     # supports_gradient_checkpointing = True
 
-    def _init_weights(self, module):
+    def _init_weights(self, module: nn.Module) -> None:
         """Initialize the weights"""
         if isinstance(module, nn.Linear):
             # Slightly different from the TF version which uses truncated_normal for initialization
@@ -268,17 +298,23 @@ class GPNPreTrainedModel(PreTrainedModel):
             if not getattr(module.weight, "_is_hf_initialized", False):
                 module.weight.data.fill_(1.0)
 
-    def _set_gradient_checkpointing(self, module, value=False):
+    def _set_gradient_checkpointing(
+        self, module: nn.Module, value: bool = False
+    ) -> None:
         if isinstance(module, RoFormerEncoder):
             module.gradient_checkpointing = value
 
 
 class GPNModel(GPNPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config: GPNConfig) -> None:
         super().__init__(config)
         self.config = config
-        self.embeddings = EMBEDDING_CLASS[config.embedding](config)
-        self.encoder = ENCODER_CLASS[config.encoder](config)
+        self.embeddings: OneHotAuxEmbedding | GPNEmbedding2 = EMBEDDING_CLASS[
+            config.embedding
+        ](config)
+        self.encoder: ConvNetEncoder | ByteNetEncoder | RoFormerEncoder = ENCODER_CLASS[
+            config.encoder
+        ](config)
         self.ln_f = nn.LayerNorm(config.hidden_size, bias=config.bias)
 
         # Fix: https://github.com/huggingface/transformers/issues/40564
@@ -287,7 +323,13 @@ class GPNModel(GPNPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def forward(self, input_ids=None, input_probs=None, aux_features=None, **kwargs):
+    def forward(
+        self,
+        input_ids: Int[Tensor, "... position"] | None = None,
+        input_probs: Float[Tensor, "... position nucleotide"] | None = None,
+        aux_features: Tensor | None = None,
+        **kwargs: Any,
+    ) -> BaseModelOutput:
         x = self.embeddings(
             input_ids=input_ids, input_probs=input_probs, aux_features=aux_features
         )
@@ -299,15 +341,15 @@ class GPNModel(GPNPreTrainedModel):
 
         return x
 
-    def get_input_embeddings(self):
+    def get_input_embeddings(self) -> nn.Module | None:
         return self.embeddings.word_embeddings
 
-    def set_input_embeddings(self, value):
+    def set_input_embeddings(self, value: nn.Module | None) -> None:
         self.embeddings.word_embeddings = value
 
 
 class GPNForMaskedLM(GPNPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config: GPNConfig) -> None:
         super().__init__(config)
         self.model = GPNModel(config)
         self.cls = MLMHead(config)
@@ -318,7 +360,13 @@ class GPNForMaskedLM(GPNPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def forward(self, labels=None, output_probs=None, loss_weight=None, **kwargs):
+    def forward(
+        self,
+        labels: Int[Tensor, "..."] | None = None,
+        output_probs: Float[Tensor, "... nucleotide"] | None = None,
+        loss_weight: Float[Tensor, "..."] | None = None,
+        **kwargs: Any,
+    ) -> MaskedLMOutput:
         hidden_state = self.model(**kwargs).last_hidden_state
         logits = self.cls(hidden_state)
         loss = masked_lm_loss(
@@ -329,21 +377,26 @@ class GPNForMaskedLM(GPNPreTrainedModel):
             logits=logits,
         )
 
-    def get_output_embeddings(self):
+    def get_output_embeddings(self) -> nn.Module | None:
         # we want to prevent tying weights to None
         if self.model.get_input_embeddings() is not None:
             return self.cls.decoder
+        return None
 
-    def set_output_embeddings(self, new_embeddings):
+    def set_output_embeddings(self, new_embeddings: nn.Module) -> None:
         self.cls.decoder = new_embeddings
 
 
 class GPNForSequenceClassification(GPNPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config: GPNConfig) -> None:
         super().__init__(config)
         self.num_labels = config.num_labels
         self.model = GPNModel(config)
-        self.classifier = CLASSIFICATION_HEAD_CLASS[config.classification_head](config)
+        self.classifier: (
+            StandardClassificationHead
+            | LightweightMLPClassificationHead
+            | LightweightCNNClassificationHead
+        ) = CLASSIFICATION_HEAD_CLASS[config.classification_head](config)
         self.regression_softplus = config.regression_softplus
 
         # Initialize weights and apply final processing
@@ -351,10 +404,10 @@ class GPNForSequenceClassification(GPNPreTrainedModel):
 
     def forward(
         self,
-        input_ids: torch.LongTensor | None = None,
-        aux_features=None,
-        labels: torch.LongTensor | None = None,
-    ) -> SequenceClassifierOutput | tuple[torch.Tensor]:
+        input_ids: Int[Tensor, "batch position"] | None = None,
+        aux_features: Tensor | None = None,
+        labels: Tensor | None = None,
+    ) -> SequenceClassifierOutput:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
@@ -403,7 +456,7 @@ class GPNForSequenceClassification(GPNPreTrainedModel):
 
 
 class GPNForTokenClassification(GPNPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config: GPNConfig) -> None:
         super().__init__(config)
         self.num_labels = config.num_labels
         self.pos_weight = config.pos_weight
@@ -421,9 +474,9 @@ class GPNForTokenClassification(GPNPreTrainedModel):
 
     def forward(
         self,
-        input_ids: torch.LongTensor | None = None,
-        aux_features=None,
-        labels: torch.LongTensor | None = None,
+        input_ids: Int[Tensor, "batch position"] | None = None,
+        aux_features: Tensor | None = None,
+        labels: Tensor | None = None,
     ) -> TokenClassifierOutput:
         x = self.model(input_ids=input_ids, aux_features=aux_features).last_hidden_state
         x = self.dropout(x)
@@ -442,7 +495,7 @@ class GPNForTokenClassification(GPNPreTrainedModel):
 
 
 class ConvNetMLMHead(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: ConvNetConfig) -> None:
         super().__init__()
         self.decoder = nn.Sequential(
             nn.Linear(config.hidden_size, config.hidden_size),
@@ -451,21 +504,27 @@ class ConvNetMLMHead(nn.Module):
             nn.Linear(config.hidden_size, config.vocab_size),
         )
 
-    def forward(self, hidden_state):
+    def forward(
+        self, hidden_state: Float[Tensor, "... position hidden"]
+    ) -> Float[Tensor, "... position nucleotide"]:
         return self.decoder(hidden_state)
 
 
 class ConvNetClassificationHead(nn.Module):
     """Head used by the published sorghum sequence-classification models."""
 
-    def __init__(self, config):
+    def __init__(self, config: ConvNetConfig) -> None:
         super().__init__()
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
         self.config = config
 
-    def forward(self, features, **kwargs):
+    def forward(
+        self,
+        features: Float[Tensor, "batch position hidden"],
+        **kwargs: Any,
+    ) -> Float[Tensor, "batch label"]:
         x = features.mean(axis=1)
         x = self.dropout(x)
         x = self.dense(x)
@@ -481,22 +540,22 @@ class ConvNetConfig(PretrainedConfig):
 
     def __init__(
         self,
-        vocab_size=7,
-        hidden_size=512,
-        n_layers=25,
-        kernel_size=9,
-        dilation_double_every=1,
-        dilation_max=32,
-        dilation_cycle=6,
-        dilation_base=2,
-        initializer_range=0.02,
-        n_aux_features=0,
-        aux_features_vocab_size=5,
-        hidden_dropout_prob=0.1,
-        hidden_act="gelu",
-        regression_softplus=False,
-        **kwargs,
-    ):
+        vocab_size: int = 7,
+        hidden_size: int = 512,
+        n_layers: int = 25,
+        kernel_size: int = 9,
+        dilation_double_every: int = 1,
+        dilation_max: int = 32,
+        dilation_cycle: int = 6,
+        dilation_base: int = 2,
+        initializer_range: float = 0.02,
+        n_aux_features: int = 0,
+        aux_features_vocab_size: int | None = 5,
+        hidden_dropout_prob: float = 0.1,
+        hidden_act: str = "gelu",
+        regression_softplus: bool = False,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.vocab_size = vocab_size
         self.n_layers = n_layers
@@ -519,7 +578,7 @@ class ConvNetPreTrainedModel(PreTrainedModel):
     base_model_prefix = "model"
     _keys_to_ignore_on_load_missing = [r"position_ids"]
 
-    def _init_weights(self, module):
+    def _init_weights(self, module: nn.Module) -> None:
         if isinstance(module, nn.Linear):
             module.weight.data.normal_(mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
@@ -534,13 +593,17 @@ class ConvNetPreTrainedModel(PreTrainedModel):
 
 
 class _TransposeLayer(nn.Module):
-    def forward(self, x):
+    def forward(
+        self, x: Float[Tensor, "batch first second"]
+    ) -> Float[Tensor, "batch second first"]:
         return torch.transpose(x, 1, 2)
 
 
 class _ConvLayer(nn.Module):
-    def __init__(self, hidden_size=None, **kwargs):
+    def __init__(self, hidden_size: int | None = None, **kwargs: Any) -> None:
         super().__init__()
+        if hidden_size is None:
+            raise ValueError("hidden_size is required")
         self.conv = nn.Sequential(
             _TransposeLayer(),
             nn.Conv1d(
@@ -559,12 +622,14 @@ class _ConvLayer(nn.Module):
             nn.LayerNorm(hidden_size),
         )
 
-    def forward(self, x):
+    def forward(
+        self, x: Float[Tensor, "... position hidden"]
+    ) -> Float[Tensor, "... position hidden"]:
         x = x + self.conv(x)
         return x + self.ffn(x)
 
 
-def _get_dilation_schedule(config):
+def _get_dilation_schedule(config: ConvNetConfig) -> list[int]:
     return [
         min(
             config.dilation_base ** (i // config.dilation_double_every),
@@ -575,7 +640,7 @@ def _get_dilation_schedule(config):
 
 
 class ConvNetModel(ConvNetPreTrainedModel):
-    def __init__(self, config, **kwargs):
+    def __init__(self, config: ConvNetConfig, **kwargs: Any) -> None:
         super().__init__(config)
         self.config = config
         self.embedding = OneHotAuxEmbedding(config)
@@ -592,7 +657,13 @@ class ConvNetModel(ConvNetPreTrainedModel):
         )
         self.post_init()
 
-    def forward(self, input_ids=None, input_probs=None, aux_features=None, **kwargs):
+    def forward(
+        self,
+        input_ids: Int[Tensor, "... position"] | None = None,
+        input_probs: Float[Tensor, "... position nucleotide"] | None = None,
+        aux_features: Tensor | None = None,
+        **kwargs: Any,
+    ) -> BaseModelOutput:
         x = self.embedding(
             input_ids=input_ids,
             input_probs=input_probs,
@@ -602,14 +673,20 @@ class ConvNetModel(ConvNetPreTrainedModel):
 
 
 class ConvNetForMaskedLM(ConvNetPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config: ConvNetConfig) -> None:
         super().__init__(config)
         self.config = config
         self.model = ConvNetModel(config)
         self.cls = ConvNetMLMHead(config)
         self.post_init()
 
-    def forward(self, labels=None, output_probs=None, loss_weight=None, **kwargs):
+    def forward(
+        self,
+        labels: Int[Tensor, "..."] | None = None,
+        output_probs: Float[Tensor, "... nucleotide"] | None = None,
+        loss_weight: Float[Tensor, "..."] | None = None,
+        **kwargs: Any,
+    ) -> MaskedLMOutput:
         hidden_state = self.model(**kwargs).last_hidden_state
         logits = self.cls(hidden_state)
         loss = masked_lm_loss(
@@ -619,7 +696,7 @@ class ConvNetForMaskedLM(ConvNetPreTrainedModel):
 
 
 class ConvNetForSequenceClassification(ConvNetPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config: ConvNetConfig) -> None:
         super().__init__(config)
         self.num_labels = config.num_labels
         self.model = ConvNetModel(config)
@@ -629,10 +706,10 @@ class ConvNetForSequenceClassification(ConvNetPreTrainedModel):
 
     def forward(
         self,
-        input_ids: torch.LongTensor | None = None,
-        labels: torch.LongTensor | None = None,
-        **kwargs,
-    ) -> SequenceClassifierOutput | tuple[torch.Tensor]:
+        input_ids: Int[Tensor, "batch position"] | None = None,
+        labels: Tensor | None = None,
+        **kwargs: Any,
+    ) -> SequenceClassifierOutput:
         hidden_state = self.model(input_ids=input_ids).last_hidden_state
         logits = self.classifier(hidden_state)
         if self.regression_softplus:

--- a/src/gpn/ss/modules.py
+++ b/src/gpn/ss/modules.py
@@ -1,18 +1,40 @@
+from typing import Any, Protocol
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from jaxtyping import Float, Int
+from torch import Tensor
 from transformers.modeling_outputs import (
     BaseModelOutput,
 )
 
 
+class EncoderConfig(Protocol):
+    """GPN configuration fields consumed by convolutional encoders."""
+
+    dilation_max: int
+    dilation_base: int
+    dilation_cycle: int
+    dilation_double_every: int
+    num_hidden_layers: int
+    hidden_size: int
+    intermediate_size: int
+    first_kernel_size: int
+    rest_kernel_size: int
+    hidden_dropout_prob: float
+    bias: bool
+    depthwise: bool
+    slim: bool
+
+
 class TransposeLayer(nn.Module):
-    def __init__(
-        self,
-    ):
+    def __init__(self) -> None:
         super().__init__()
 
-    def forward(self, x):
+    def forward(
+        self, x: Float[Tensor, "batch first second"]
+    ) -> Float[Tensor, "batch second first"]:
         x = torch.transpose(x, 1, 2)
         return x
 
@@ -85,13 +107,17 @@ class TransposeLayer(nn.Module):
 class ConvLayer(nn.Module):
     def __init__(
         self,
-        hidden_size=None,
-        intermediate_size=None,
-        hidden_dropout_prob=None,
-        bias=None,
-        **kwargs,
-    ):
+        hidden_size: int | None = None,
+        intermediate_size: int | None = None,
+        hidden_dropout_prob: float | None = None,
+        bias: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__()
+        if hidden_size is None or intermediate_size is None:
+            raise ValueError("hidden_size and intermediate_size are required")
+        if hidden_dropout_prob is None:
+            raise ValueError("hidden_dropout_prob is required")
         self.conv = nn.Sequential(
             nn.LayerNorm(hidden_size, bias=bias),
             TransposeLayer(),
@@ -115,7 +141,9 @@ class ConvLayer(nn.Module):
             nn.Dropout(hidden_dropout_prob),
         )
 
-    def forward(self, x):
+    def forward(
+        self, x: Float[Tensor, "... position hidden"]
+    ) -> Float[Tensor, "... position hidden"]:
         x = x + self.conv(x)
         x = x + self.ffn(x)
         return x
@@ -124,12 +152,14 @@ class ConvLayer(nn.Module):
 class ByteNetLayer(nn.Module):
     def __init__(
         self,
-        hidden_size=None,
-        slim=False,
-        bias=None,
-        **kwargs,
-    ):
+        hidden_size: int | None = None,
+        slim: bool = False,
+        bias: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__()
+        if hidden_size is None:
+            raise ValueError("hidden_size is required")
         intermediate_size = hidden_size // 2 if slim else hidden_size
         self.layer = nn.Sequential(
             nn.LayerNorm(hidden_size, bias=bias),
@@ -151,7 +181,9 @@ class ByteNetLayer(nn.Module):
             nn.Linear(intermediate_size, hidden_size, bias=bias),
         )
 
-    def forward(self, x):
+    def forward(
+        self, x: Float[Tensor, "... position hidden"]
+    ) -> Float[Tensor, "... position hidden"]:
         x = x + self.layer(x)
         return x
 
@@ -159,16 +191,20 @@ class ByteNetLayer(nn.Module):
 class OneHotEmbedding(nn.Module):
     def __init__(
         self,
-        hidden_size=None,
-    ):
+        hidden_size: int | None = None,
+    ) -> None:
         super().__init__()
+        if hidden_size is None:
+            raise ValueError("hidden_size is required")
         self.hidden_size = hidden_size
 
-    def forward(self, x):
+    def forward(
+        self, x: Int[Tensor, "... position"]
+    ) -> Float[Tensor, "... position hidden"]:
         return F.one_hot(x, num_classes=self.hidden_size).float()
 
 
-def get_dilation_schedule(config):
+def get_dilation_schedule(config: EncoderConfig) -> list[int]:
     return [
         min(
             config.dilation_max,
@@ -180,7 +216,7 @@ def get_dilation_schedule(config):
 
 
 class ConvNetEncoder(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: EncoderConfig) -> None:
         super().__init__()
         dilation_schedule = get_dilation_schedule(config)
         print(f"{dilation_schedule=}")
@@ -203,13 +239,15 @@ class ConvNetEncoder(nn.Module):
             ]
         )
 
-    def forward(self, hidden_states):
+    def forward(
+        self, hidden_states: Float[Tensor, "... position hidden"]
+    ) -> BaseModelOutput:
         hidden_states = self.layer(hidden_states)
         return BaseModelOutput(last_hidden_state=hidden_states)
 
 
 class ByteNetEncoder(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: EncoderConfig) -> None:
         super().__init__()
         dilation_schedule = get_dilation_schedule(config)
         print(f"{dilation_schedule=}")
@@ -231,13 +269,15 @@ class ByteNetEncoder(nn.Module):
             ]
         )
 
-    def forward(self, hidden_states):
+    def forward(
+        self, hidden_states: Float[Tensor, "... position hidden"]
+    ) -> BaseModelOutput:
         hidden_states = self.layer(hidden_states)
         return BaseModelOutput(last_hidden_state=hidden_states)
 
 
 class MLP(nn.Module):
-    def __init__(self, input_size, hidden_size, output_size):
+    def __init__(self, input_size: int, hidden_size: int, output_size: int) -> None:
         super().__init__()
         self.layer = nn.Sequential(
             nn.LayerNorm(input_size, bias=False),
@@ -250,15 +290,22 @@ class MLP(nn.Module):
         else:
             self.shortcut = nn.Identity()
 
-    def forward(self, x):
+    def forward(self, x: Float[Tensor, "... input"]) -> Float[Tensor, "... output"]:
         return self.shortcut(x) + self.layer(x)
 
 
 class CNN(nn.Module):
     def __init__(
-        self, input_size, hidden_size, output_size, kernel_size=None, **kwargs
-    ):
+        self,
+        input_size: int,
+        hidden_size: int,
+        output_size: int,
+        kernel_size: int | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__()
+        if kernel_size is None:
+            raise ValueError("kernel_size is required")
         self.layer = nn.Sequential(
             nn.LayerNorm(input_size, bias=False),
             TransposeLayer(),
@@ -279,5 +326,7 @@ class CNN(nn.Module):
         else:
             self.shortcut = nn.Identity()
 
-    def forward(self, x):
+    def forward(
+        self, x: Float[Tensor, "... position input"]
+    ) -> Float[Tensor, "... position output"]:
         return self.shortcut(x) + self.layer(x)

--- a/src/gpn/star/inference.py
+++ b/src/gpn/star/inference.py
@@ -9,6 +9,8 @@ import numpy as np
 import pandas as pd
 import torch
 from datasets import Dataset, disable_caching
+from jaxtyping import Float, Int
+from torch import Tensor
 from transformers import AutoModel, AutoModelForMaskedLM, TrainingArguments
 
 from gpn import register_auto_classes
@@ -45,13 +47,13 @@ class MLMforVEPModel(torch.nn.Module):
 
     def get_llr(
         self,
-        input_ids: torch.Tensor,
-        source_ids: torch.Tensor,
-        target_species: torch.Tensor,
-        pos: torch.Tensor,
-        ref: torch.Tensor,
-        alt: torch.Tensor,
-    ) -> torch.Tensor:
+        input_ids: Int[Tensor, "batch position target"],
+        source_ids: Int[Tensor, "batch position species"],
+        target_species: Int[Tensor, "batch target"],
+        pos: Int[Tensor, "... batch"],
+        ref: Int[Tensor, "... batch"],
+        alt: Int[Tensor, "... batch"],
+    ) -> Float[Tensor, "... batch"]:
         logits = self.model(
             input_ids=input_ids,
             source_ids=source_ids,
@@ -63,18 +65,18 @@ class MLMforVEPModel(torch.nn.Module):
 
     def forward(
         self,
-        input_ids_fwd: torch.Tensor | None = None,
-        source_ids_fwd: torch.Tensor | None = None,
-        pos_fwd: torch.Tensor | None = None,
-        ref_fwd: torch.Tensor | None = None,
-        alt_fwd: torch.Tensor | None = None,
-        input_ids_rev: torch.Tensor | None = None,
-        source_ids_rev: torch.Tensor | None = None,
-        pos_rev: torch.Tensor | None = None,
-        ref_rev: torch.Tensor | None = None,
-        alt_rev: torch.Tensor | None = None,
-        target_species: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        input_ids_fwd: Int[Tensor, "batch position target"] | None = None,
+        source_ids_fwd: Int[Tensor, "batch position species"] | None = None,
+        pos_fwd: Int[Tensor, "... batch"] | None = None,
+        ref_fwd: Int[Tensor, "... batch"] | None = None,
+        alt_fwd: Int[Tensor, "... batch"] | None = None,
+        input_ids_rev: Int[Tensor, "batch position target"] | None = None,
+        source_ids_rev: Int[Tensor, "batch position species"] | None = None,
+        pos_rev: Int[Tensor, "... batch"] | None = None,
+        ref_rev: Int[Tensor, "... batch"] | None = None,
+        alt_rev: Int[Tensor, "... batch"] | None = None,
+        target_species: Int[Tensor, "batch target"] | None = None,
+    ) -> Float[Tensor, "... batch"]:
         llr_fwd = self.get_llr(
             input_ids_fwd,
             source_ids_fwd,
@@ -114,11 +116,11 @@ class MLMforLogitsModel(torch.nn.Module):
 
     def get_logits(
         self,
-        input_ids: torch.Tensor,
-        source_ids: torch.Tensor,
-        target_species: torch.Tensor,
-        pos: torch.Tensor,
-    ) -> torch.Tensor:
+        input_ids: Int[Tensor, "batch position target"],
+        source_ids: Int[Tensor, "batch position species"],
+        target_species: Int[Tensor, "batch target"],
+        pos: Int[Tensor, "... batch"],
+    ) -> Float[Tensor, "batch nucleotide"]:
         logits = self.model(
             input_ids=input_ids,
             source_ids=source_ids,
@@ -128,14 +130,14 @@ class MLMforLogitsModel(torch.nn.Module):
 
     def forward(
         self,
-        input_ids_fwd: torch.Tensor | None = None,
-        source_ids_fwd: torch.Tensor | None = None,
-        pos_fwd: torch.Tensor | None = None,
-        input_ids_rev: torch.Tensor | None = None,
-        source_ids_rev: torch.Tensor | None = None,
-        pos_rev: torch.Tensor | None = None,
-        target_species: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        input_ids_fwd: Int[Tensor, "batch position target"] | None = None,
+        source_ids_fwd: Int[Tensor, "batch position species"] | None = None,
+        pos_fwd: Int[Tensor, "... batch"] | None = None,
+        input_ids_rev: Int[Tensor, "batch position target"] | None = None,
+        source_ids_rev: Int[Tensor, "batch position species"] | None = None,
+        pos_rev: Int[Tensor, "... batch"] | None = None,
+        target_species: Int[Tensor, "batch target"] | None = None,
+    ) -> Float[Tensor, "batch nucleotide"]:
         a, c, g, t = self.nucleotide_ids
         logits_fwd = self.get_logits(
             input_ids_fwd, source_ids_fwd, target_species, pos_fwd
@@ -163,10 +165,10 @@ class ModelCenterEmbedding(torch.nn.Module):
 
     def get_center_embedding(
         self,
-        input_ids: torch.Tensor,
-        source_ids: torch.Tensor,
-        target_species: torch.Tensor,
-    ) -> torch.Tensor:
+        input_ids: Int[Tensor, "batch position target"],
+        source_ids: Int[Tensor, "batch position species"],
+        target_species: Int[Tensor, "batch target"],
+    ) -> Float[Tensor, "batch target hidden"]:
         embedding = self.model(
             input_ids=input_ids,
             source_ids=source_ids,
@@ -181,12 +183,12 @@ class ModelCenterEmbedding(torch.nn.Module):
 
     def forward(
         self,
-        input_ids_fwd: torch.Tensor | None = None,
-        input_ids_rev: torch.Tensor | None = None,
-        source_ids_fwd: torch.Tensor | None = None,
-        source_ids_rev: torch.Tensor | None = None,
-        target_species: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        input_ids_fwd: Int[Tensor, "batch position target"] | None = None,
+        input_ids_rev: Int[Tensor, "batch position target"] | None = None,
+        source_ids_fwd: Int[Tensor, "batch position species"] | None = None,
+        source_ids_rev: Int[Tensor, "batch position species"] | None = None,
+        target_species: Int[Tensor, "batch target"] | None = None,
+    ) -> Float[Tensor, "batch target hidden"]:
         embedding_fwd = self.get_center_embedding(
             input_ids_fwd, source_ids_fwd, target_species
         )

--- a/src/gpn/star/model.py
+++ b/src/gpn/star/model.py
@@ -247,23 +247,21 @@ class GPNStarSourceModule(nn.Module):
         )
 
         # Attention pooling: per-species token -> per-clade token
-        clade_pooled_source_ids: list[Tensor] = []
+        clade_embeddings: list[Tensor] = []
         for species in clade_dict.values():
             species_indices = list(species)
             if len(species_indices) > 1:
-                clade_pooled_source_ids.append(
+                clade_embeddings.append(
                     self.attn_pool(
                         source_ids[..., species_indices].to(torch.int),  # (B, L, N_c)
                         in_clade_time_bias[..., species_indices],
                     )
                 )  # (B, L, A, 1, N_c)
             else:
-                clade_pooled_source_ids.append(
+                clade_embeddings.append(
                     self.embed(source_ids[..., species_indices[0]].to(torch.int))
                 )
-        clade_pooled_source_ids = torch.stack(
-            clade_pooled_source_ids, dim=-2
-        )  # (B, L, C, H)
+        clade_pooled_source_ids = torch.stack(clade_embeddings, dim=-2)
 
         return clade_pooled_source_ids
 

--- a/src/gpn/star/model.py
+++ b/src/gpn/star/model.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
 import math
 import os
 import shutil
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from typing import Any, Self, overload
 
 import networkx as nx
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from jaxtyping import Float, Int
+from torch import Tensor
 from torch.nn import CrossEntropyLoss
 from transformers import PreTrainedModel, RoFormerConfig, apply_chunking_to_forward
 from transformers.modeling_outputs import (
@@ -27,16 +33,16 @@ class GPNStarConfig(RoFormerConfig):
 
     def __init__(
         self,
-        vocab_size=6,
-        time_enc="fire_1",
-        phylo_dist_path=None,
-        clade_thres=0.2,
-        **kwargs,
-    ):
+        vocab_size: int = 6,
+        time_enc: str = "fire_1",
+        phylo_dist_path: str | None = None,
+        clade_thres: float = 0.2,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.vocab_size = vocab_size
         self.time_enc = time_enc
-        self.max_evol_dist = None
+        self.max_evol_dist: float | None = None
         self.phylo_dist_path = phylo_dist_path
         self.clade_thres = clade_thres
 
@@ -44,7 +50,12 @@ class GPNStarConfig(RoFormerConfig):
 _PHYLO_DIST_FILENAMES = ("pairwise.npy", "in_clade.npy")
 
 
-def _contains_phylo_dist_files(path):
+def _parse_time_encoding(value: str) -> tuple[str, int]:
+    encoding, scale = value.split("_")
+    return encoding, int(scale)
+
+
+def _contains_phylo_dist_files(path: str | os.PathLike[str] | None) -> bool:
     return path is not None and all(
         os.path.isfile(os.path.join(path, filename))
         for filename in _PHYLO_DIST_FILENAMES
@@ -52,12 +63,12 @@ def _contains_phylo_dist_files(path):
 
 
 def _resolve_phylo_dist_path(
-    pretrained_model_name_or_path,
-    config,
+    pretrained_model_name_or_path: str | os.PathLike[str],
+    config: GPNStarConfig,
     *,
-    explicit_path=None,
-    hub_kwargs=None,
-):
+    explicit_path: str | os.PathLike[str] | None = None,
+    hub_kwargs: Mapping[str, Any] | None = None,
+) -> str:
     """Resolve local or Hub-hosted phylogenetic-distance model assets."""
     if explicit_path is not None:
         explicit_path = os.fsdecode(os.fspath(explicit_path))
@@ -72,6 +83,7 @@ def _resolve_phylo_dist_path(
     if configured_path is not None:
         configured_path = os.fsdecode(os.fspath(configured_path))
     if _contains_phylo_dist_files(configured_path):
+        assert configured_path is not None
         return configured_path
 
     model_path = os.fsdecode(os.fspath(pretrained_model_name_or_path))
@@ -88,7 +100,7 @@ def _resolve_phylo_dist_path(
     from huggingface_hub import snapshot_download
 
     asset_dir = "/".join(part for part in (subfolder, "phylo_dist") if part)
-    download_kwargs = {
+    download_kwargs: dict[str, Any] = {
         key: (hub_kwargs or {})[key]
         for key in (
             "cache_dir",
@@ -119,7 +131,7 @@ def _resolve_phylo_dist_path(
 
 
 class FIRETimeBias(nn.Module):
-    def __init__(self, max_dist, fire_hidden_size=32):
+    def __init__(self, max_dist: float, fire_hidden_size: int = 32) -> None:
         super().__init__()
         self.c = nn.Parameter(torch.tensor(100, dtype=torch.float32))
         self.mlp = nn.Sequential(
@@ -129,7 +141,9 @@ class FIRETimeBias(nn.Module):
         )
         self.max_dist = max_dist
 
-    def forward(self, rel_pos: torch.tensor) -> torch.tensor:
+    def forward(
+        self, rel_pos: Float[Tensor, "batch target source"]
+    ) -> Float[Tensor, "batch 1 1 target source"]:
         rel_pos = rel_pos[:, None, None, :, :, None].to(
             torch.float32
         )  # (B, 1 (L), 1 (A), T, C, 1)
@@ -139,19 +153,23 @@ class FIRETimeBias(nn.Module):
 
 
 class GPNStarEmbedding(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
         self.vocab_size = config.vocab_size
         self.hidden_size = config.hidden_size
         self.input_embed = nn.Embedding(self.vocab_size, self.hidden_size)
 
-    def forward(self, input_ids=None):
+    def forward(
+        self, input_ids: Int[Tensor, "batch position target"] | None = None
+    ) -> Float[Tensor, "batch position target hidden"]:
+        if input_ids is None:
+            raise ValueError("input_ids are required")
         target_embeddings = self.input_embed(input_ids.to(torch.int))
         return target_embeddings  # (B, L, T, H)
 
 
 class GPNStarAttentionPool(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
 
         self.num_attention_heads = config.num_attention_heads // 2
@@ -167,7 +185,7 @@ class GPNStarAttentionPool(nn.Module):
 
         self.ffn = nn.Linear(self.all_head_size, config.hidden_size)
 
-    def transpose_for_scores(self, x):
+    def transpose_for_scores(self, x: Tensor) -> Tensor:
         new_x_shape = x.size()[:-1] + (
             self.num_attention_heads,
             self.attention_head_size,
@@ -175,7 +193,11 @@ class GPNStarAttentionPool(nn.Module):
         x = x.view(*new_x_shape)
         return x.transpose(-2, -3)
 
-    def forward(self, source_ids, in_clade_time_bias):
+    def forward(
+        self,
+        source_ids: Int[Tensor, "batch position species"],
+        in_clade_time_bias: Float[Tensor, "batch 1 head 1 species"],
+    ) -> Float[Tensor, "batch position hidden"]:
         attention_scores = (
             self.attention_weights(source_ids).transpose(-1, -2).unsqueeze(-2)
         )  # (B, L, A, 1, N_c)
@@ -199,39 +221,45 @@ class GPNStarAttentionPool(nn.Module):
 
 
 class GPNStarSourceModule(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
 
         self.attn_pool = GPNStarAttentionPool(config)
         self.embed = nn.Embedding(config.vocab_size, config.hidden_size)
-        self.time_enc, self.time_scale = config.time_enc.split("_")
-        self.time_scale = int(self.time_scale)
+        self.time_enc, self.time_scale = _parse_time_encoding(config.time_enc)
 
         # time embedding modules. Move to higher level?
         if self.time_enc == "fire":
+            if config.max_evol_dist is None:
+                raise ValueError("max_evol_dist must be set before model construction")
             self.embed_positions = FIRETimeBias(config.max_evol_dist)
         else:
             raise ValueError("time encoding not implemented.")
 
-    def forward(self, source_ids, clade_dict, in_clade_phylo_dist):
+    def forward(
+        self,
+        source_ids: Int[Tensor, "batch position species"],
+        clade_dict: Mapping[int, set[int]],
+        in_clade_phylo_dist: Float[Tensor, "... species"],
+    ) -> Float[Tensor, "batch position clade hidden"]:
         in_clade_time_bias = self.embed_positions(
             in_clade_phylo_dist[None, None, :] * self.time_scale
         )
 
         # Attention pooling: per-species token -> per-clade token
-        clade_pooled_source_ids = []
-        for clade, species in clade_dict.items():
-            species = list(species)
-            if len(species) > 1:
+        clade_pooled_source_ids: list[Tensor] = []
+        for species in clade_dict.values():
+            species_indices = list(species)
+            if len(species_indices) > 1:
                 clade_pooled_source_ids.append(
                     self.attn_pool(
-                        source_ids[..., species].to(torch.int),  # (B, L, N_c)
-                        in_clade_time_bias[..., species],
+                        source_ids[..., species_indices].to(torch.int),  # (B, L, N_c)
+                        in_clade_time_bias[..., species_indices],
                     )
                 )  # (B, L, A, 1, N_c)
             else:
                 clade_pooled_source_ids.append(
-                    self.embed(source_ids[..., species[0]].to(torch.int))
+                    self.embed(source_ids[..., species_indices[0]].to(torch.int))
                 )
         clade_pooled_source_ids = torch.stack(
             clade_pooled_source_ids, dim=-2
@@ -241,7 +269,7 @@ class GPNStarSourceModule(nn.Module):
 
 
 class GPNStarColCrossAttention(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
         if config.hidden_size % config.num_attention_heads != 0 and not hasattr(
             config, "embedding_size"
@@ -256,8 +284,7 @@ class GPNStarColCrossAttention(nn.Module):
         self.all_head_size = self.num_attention_heads * self.attention_head_size
 
         # Time encoding
-        self.time_enc, self.time_scale = config.time_enc.split("_")
-        self.time_scale = int(self.time_scale)
+        self.time_enc, self.time_scale = _parse_time_encoding(config.time_enc)
 
         self.query = nn.Linear(config.hidden_size, self.all_head_size)
         self.key = nn.Linear(config.hidden_size, self.all_head_size)
@@ -265,7 +292,7 @@ class GPNStarColCrossAttention(nn.Module):
 
         self.attention_probs_dropout_prob = config.attention_probs_dropout_prob
 
-    def transpose_for_scores(self, x):
+    def transpose_for_scores(self, x: Tensor) -> Tensor:
         new_x_shape = x.size()[:-1] + (
             self.num_attention_heads,
             self.attention_head_size,
@@ -275,12 +302,14 @@ class GPNStarColCrossAttention(nn.Module):
 
     def forward(
         self,
-        hidden_states,
-        source_embeddings,
-        attention_mask=None,
-        evol_time_bias=None,
-        output_attentions=False,
-    ):
+        hidden_states: Float[Tensor, "batch position target hidden"],
+        source_embeddings: Float[Tensor, "batch position clade hidden"],
+        attention_mask: Float[Tensor, "batch 1 1 target clade"] | None = None,
+        evol_time_bias: Float[Tensor, "batch 1 head target clade"] | None = None,
+        output_attentions: bool = False,
+    ) -> tuple[Tensor, ...]:
+        if attention_mask is None or evol_time_bias is None:
+            raise ValueError("attention_mask and evol_time_bias are required")
         query_layer = self.transpose_for_scores(self.query(hidden_states))
         key_layer = self.transpose_for_scores(self.key(source_embeddings))
         value_layer = self.transpose_for_scores(self.value(source_embeddings))
@@ -302,7 +331,7 @@ class GPNStarColCrossAttention(nn.Module):
             new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
             context_layer = context_layer.view(*new_context_layer_shape)
 
-            outputs = (
+            outputs: tuple[Tensor, ...] = (
                 (context_layer, attention_probs)
                 if output_attentions
                 else (context_layer,)
@@ -333,15 +362,19 @@ class GPNStarColCrossAttention(nn.Module):
 
 
 class GPNStarColCrossOutput(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
         self.dense = nn.Linear(config.hidden_size // 2, config.hidden_size)
         self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
     def forward(
-        self, hidden_states: torch.Tensor, input_tensor: torch.Tensor = None
-    ) -> torch.Tensor:
+        self,
+        hidden_states: Float[Tensor, "batch position target half_hidden"],
+        input_tensor: Float[Tensor, "batch position target hidden"] | None = None,
+    ) -> Float[Tensor, "batch position target hidden"]:
+        if input_tensor is None:
+            raise ValueError("input_tensor is required")
         hidden_states = self.dense(hidden_states)
         hidden_states = self.dropout(hidden_states)
         hidden_states = self.LayerNorm(hidden_states + input_tensor)
@@ -349,27 +382,30 @@ class GPNStarColCrossOutput(nn.Module):
 
 
 class GPNStarColAttention(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
         self.self = GPNStarColCrossAttention(config)
         self.out = GPNStarColCrossOutput(config)
 
-        self.time_enc, self.time_scale = config.time_enc.split("_")
-        self.time_scale = int(self.time_scale)
+        self.time_enc, self.time_scale = _parse_time_encoding(config.time_enc)
 
         if self.time_enc == "fire":
+            if config.max_evol_dist is None:
+                raise ValueError("max_evol_dist must be set before model construction")
             self.embed_positions = FIRETimeBias(config.max_evol_dist)
         else:
             raise ValueError(f"Time encoding {self.time_enc} not implemented!")
 
     def forward(
         self,
-        hidden_states,
-        source_embeddings,
-        attention_mask=None,
-        phylo_dist=None,
-        output_attentions=False,
-    ):
+        hidden_states: Float[Tensor, "batch position target hidden"],
+        source_embeddings: Float[Tensor, "batch position clade hidden"],
+        attention_mask: Float[Tensor, "batch 1 1 target clade"] | None = None,
+        phylo_dist: Float[Tensor, "batch target clade"] | None = None,
+        output_attentions: bool = False,
+    ) -> tuple[Tensor, ...]:
+        if phylo_dist is None:
+            raise ValueError("phylo_dist is required")
         evol_time_bias = self.embed_positions(phylo_dist)
 
         self_outputs = self.self(
@@ -379,14 +415,14 @@ class GPNStarColAttention(nn.Module):
             evol_time_bias=evol_time_bias,
             output_attentions=output_attentions,
         )
-        output = (self.out(self_outputs[0], hidden_states),)
+        output: tuple[Tensor, ...] = (self.out(self_outputs[0], hidden_states),)
         if output_attentions:
             output = output + (self_outputs[1],)
         return output
 
 
 class GPNStarRowSelfAttention(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
         if config.hidden_size % config.num_attention_heads != 0 and not hasattr(
             config, "embedding_size"
@@ -400,8 +436,7 @@ class GPNStarRowSelfAttention(nn.Module):
         self.attention_head_size = int(config.hidden_size / config.num_attention_heads)
         self.all_head_size = self.num_attention_heads * self.attention_head_size
 
-        self.time_enc, self.time_scale = config.time_enc.split("_")
-        self.time_scale = int(self.time_scale)
+        self.time_enc, self.time_scale = _parse_time_encoding(config.time_enc)
 
         self.query = nn.Linear(config.hidden_size, self.all_head_size)
         self.key = nn.Linear(config.hidden_size, self.all_head_size)
@@ -412,7 +447,7 @@ class GPNStarRowSelfAttention(nn.Module):
 
         self.rotary_value = config.rotary_value
 
-    def transpose_for_scores(self, x):
+    def transpose_for_scores(self, x: Tensor) -> Tensor:
         new_x_shape = x.size()[:-1] + (
             self.num_attention_heads,
             self.attention_head_size,
@@ -422,11 +457,12 @@ class GPNStarRowSelfAttention(nn.Module):
 
     def forward(
         self,
-        hidden_states,
-        attention_mask=None,
-        sinusoidal_pos=None,
-        output_attentions=False,
-    ):
+        hidden_states: Float[Tensor, "batch target position hidden"],
+        attention_mask: Float[Tensor, "batch 1 head position position_key"]
+        | None = None,
+        sinusoidal_pos: Float[Tensor, "1 1 position head_dimension"] | None = None,
+        output_attentions: bool = False,
+    ) -> tuple[Tensor, ...]:
         # attention scores are only calculated wrt the human genome
         query_layer = self.transpose_for_scores(self.query(hidden_states[:, :1, ...]))
         key_layer = self.transpose_for_scores(self.key(hidden_states[:, :1, ...]))
@@ -470,7 +506,7 @@ class GPNStarRowSelfAttention(nn.Module):
             context_layer = context_layer.view(
                 *new_context_layer_shape
             )  # (B, T, L, H/2)
-            outputs = (
+            outputs: tuple[Tensor, ...] = (
                 (context_layer, attention_probs)
                 if output_attentions
                 else (context_layer,)
@@ -499,9 +535,30 @@ class GPNStarRowSelfAttention(nn.Module):
         return outputs
 
     @staticmethod
+    @overload
     def apply_rotary_position_embeddings(
-        sinusoidal_pos, query_layer, key_layer, value_layer=None
-    ):
+        sinusoidal_pos: Tensor,
+        query_layer: Tensor,
+        key_layer: Tensor,
+        value_layer: None = None,
+    ) -> tuple[Tensor, Tensor]: ...
+
+    @staticmethod
+    @overload
+    def apply_rotary_position_embeddings(
+        sinusoidal_pos: Tensor,
+        query_layer: Tensor,
+        key_layer: Tensor,
+        value_layer: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor]: ...
+
+    @staticmethod
+    def apply_rotary_position_embeddings(
+        sinusoidal_pos: Tensor,
+        query_layer: Tensor,
+        key_layer: Tensor,
+        value_layer: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor] | tuple[Tensor, Tensor, Tensor]:
         # https://kexue.fm/archives/8265
         # sin [batch_size, num_heads, sequence_length, embed_size_per_head//2]
         # cos [batch_size, num_heads, sequence_length, embed_size_per_head//2]
@@ -531,15 +588,19 @@ class GPNStarRowSelfAttention(nn.Module):
 
 
 class GPNStarRowSelfOutput(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
         self.dense = nn.Linear(config.hidden_size // 2, config.hidden_size)
         self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
     def forward(
-        self, hidden_states: torch.Tensor, input_tensor: torch.Tensor = None
-    ) -> torch.Tensor:
+        self,
+        hidden_states: Float[Tensor, "batch target position half_hidden"],
+        input_tensor: Float[Tensor, "batch target position hidden"] | None = None,
+    ) -> Float[Tensor, "batch target position hidden"]:
+        if input_tensor is None:
+            raise ValueError("input_tensor is required")
         hidden_states = self.dense(hidden_states)
         hidden_states = self.dropout(hidden_states)
         hidden_states = self.LayerNorm(hidden_states + input_tensor)
@@ -547,49 +608,49 @@ class GPNStarRowSelfOutput(nn.Module):
 
 
 class GPNStarRowAttention(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
         self.self = GPNStarRowSelfAttention(config)
         self.out = GPNStarRowSelfOutput(config)
 
     def forward(
         self,
-        hidden_states,
-        attention_mask=None,
-        sinusoidal_pos=None,
-        output_attentions=False,
-    ):
+        hidden_states: Float[Tensor, "batch target position hidden"],
+        attention_mask: Tensor | None = None,
+        sinusoidal_pos: Tensor | None = None,
+        output_attentions: bool = False,
+    ) -> tuple[Tensor, ...]:
         self_outputs = self.self(
             hidden_states=hidden_states,
             attention_mask=attention_mask,
             sinusoidal_pos=sinusoidal_pos,
             output_attentions=output_attentions,
         )
-        output = (self.out(self_outputs[0], hidden_states),)
+        output: tuple[Tensor, ...] = (self.out(self_outputs[0], hidden_states),)
         if output_attentions:
             output = output + (self_outputs[1],)
         return output
 
 
 class GPNStarAttention(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__()
         self.row_attention = GPNStarRowAttention(config)
         self.col_attention = GPNStarColAttention(config)
 
     def forward(
         self,
-        hidden_states,
-        source_embeddings,
-        attention_mask=None,
-        sinusoidal_pos=None,
-        phylo_dist=None,
-        head_mask=None,
-        encoder_hidden_states=None,
-        encoder_attention_mask=None,
-        past_key_value=None,
-        output_attentions=False,
-    ):
+        hidden_states: Float[Tensor, "batch position target hidden"],
+        source_embeddings: Float[Tensor, "batch position clade hidden"],
+        attention_mask: Tensor | None = None,
+        sinusoidal_pos: Tensor | None = None,
+        phylo_dist: Float[Tensor, "batch target clade"] | None = None,
+        head_mask: Tensor | None = None,
+        encoder_hidden_states: Tensor | None = None,
+        encoder_attention_mask: Tensor | None = None,
+        past_key_value: tuple[Tensor, ...] | None = None,
+        output_attentions: bool = False,
+    ) -> tuple[Tensor, ...]:
         row_output = self.row_attention(
             hidden_states=hidden_states.transpose(-2, -3),
             attention_mask=None,
@@ -603,7 +664,7 @@ class GPNStarAttention(nn.Module):
             phylo_dist=phylo_dist,
             output_attentions=output_attentions,
         )
-        out = (col_output[0],)
+        out: tuple[Tensor, ...] = (col_output[0],)
         if output_attentions:
             out = out + (
                 row_output[1],
@@ -613,23 +674,23 @@ class GPNStarAttention(nn.Module):
 
 
 class GPNStarLayer(RoFormerLayer):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__(config)
         self.attention = GPNStarAttention(config)
 
     def forward(
         self,
-        hidden_states,
-        source_embeddings,
-        attention_mask=None,
-        sinusoidal_pos=None,
-        phylo_dist=None,
-        head_mask=None,
-        encoder_hidden_states=None,
-        encoder_attention_mask=None,
-        past_key_value=None,
-        output_attentions=False,
-    ):
+        hidden_states: Tensor,
+        source_embeddings: Tensor,
+        attention_mask: Tensor | None = None,
+        sinusoidal_pos: Tensor | None = None,
+        phylo_dist: Tensor | None = None,
+        head_mask: Tensor | None = None,
+        encoder_hidden_states: Tensor | None = None,
+        encoder_attention_mask: Tensor | None = None,
+        past_key_value: tuple[Tensor, ...] | None = None,
+        output_attentions: bool = False,
+    ) -> tuple[Any, ...]:
         # decoder uni-directional self-attention cached key/values tuple is at positions 1,2
         self_attn_past_key_value = (
             past_key_value[:2] if past_key_value is not None else None
@@ -646,6 +707,8 @@ class GPNStarLayer(RoFormerLayer):
         )
         attention_output = self_attention_outputs[0]
 
+        present_key_value: Any = None
+
         # if decoder, the last output is tuple of self-attn cache
         if self.is_decoder:
             outputs = self_attention_outputs[1:-1]
@@ -655,7 +718,6 @@ class GPNStarLayer(RoFormerLayer):
                 1:
             ]  # add self attentions if we output attention weights
 
-        cross_attn_present_key_value = None
         if self.is_decoder and encoder_hidden_states is not None:
             if not hasattr(self, "crossattention"):
                 raise ValueError(
@@ -702,7 +764,7 @@ class GPNStarLayer(RoFormerLayer):
 
 
 class GPNStarEncoder(RoFormerEncoder):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__(config)
         self.layer = nn.ModuleList(
             [GPNStarLayer(config) for _ in range(config.num_hidden_layers)]
@@ -710,25 +772,31 @@ class GPNStarEncoder(RoFormerEncoder):
 
     def forward(
         self,
-        hidden_states,
-        source_embeddings,
-        attention_mask=None,
-        head_mask=None,
-        encoder_hidden_states=None,
-        encoder_attention_mask=None,
-        past_key_values=None,
-        use_cache=None,
-        output_attentions=False,
-        output_hidden_states=False,
-        return_dict=True,
-        phylo_dist=None,
-        **kwargs,
-    ):
+        hidden_states: Tensor,
+        source_embeddings: Tensor,
+        attention_mask: Tensor | None = None,
+        head_mask: Tensor | None = None,
+        encoder_hidden_states: Tensor | None = None,
+        encoder_attention_mask: Tensor | None = None,
+        past_key_values: tuple[tuple[Tensor, ...], ...] | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+        phylo_dist: Tensor | None = None,
+        **kwargs: Any,
+    ) -> BaseModelOutputWithRowAndColAttentions | tuple[Any, ...]:
         if self.gradient_checkpointing and self.training:
             use_cache = False
-        all_hidden_states = () if output_hidden_states else None
-        all_row_attentions = () if output_attentions else None
-        all_col_attentions = () if output_attentions else None
+        all_hidden_states: tuple[Tensor, ...] | None = (
+            () if output_hidden_states else None
+        )
+        all_row_attentions: tuple[Tensor, ...] | None = (
+            () if output_attentions else None
+        )
+        all_col_attentions: tuple[Tensor, ...] | None = (
+            () if output_attentions else None
+        )
 
         past_key_values_length = (
             past_key_values[0][0].shape[2] if past_key_values is not None else 0
@@ -739,9 +807,10 @@ class GPNStarEncoder(RoFormerEncoder):
             hidden_states.shape[:-1], past_key_values_length
         )[None, None, :, :]
 
-        next_decoder_cache = () if use_cache else None
+        next_decoder_cache: tuple[Any, ...] | None = () if use_cache else None
         for i, layer_module in enumerate(self.layer):
             if output_hidden_states:
+                assert all_hidden_states is not None
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
             layer_head_mask = head_mask[i] if head_mask is not None else None
@@ -749,8 +818,8 @@ class GPNStarEncoder(RoFormerEncoder):
 
             if self.gradient_checkpointing and self.training:
 
-                def create_custom_forward(module):
-                    def custom_forward(*inputs):
+                def create_custom_forward(module: nn.Module) -> Callable[..., Any]:
+                    def custom_forward(*inputs: Any) -> Any:
                         return module(*inputs, past_key_value, output_attentions)
 
                     return custom_forward
@@ -782,12 +851,16 @@ class GPNStarEncoder(RoFormerEncoder):
 
             hidden_states = layer_outputs[0]
             if use_cache:
+                assert next_decoder_cache is not None
                 next_decoder_cache += (layer_outputs[-1],)
             if output_attentions:
+                assert all_row_attentions is not None
+                assert all_col_attentions is not None
                 all_row_attentions = all_row_attentions + (layer_outputs[1],)
                 all_col_attentions = all_col_attentions + (layer_outputs[2],)
 
         if output_hidden_states:
+            assert all_hidden_states is not None
             all_hidden_states = all_hidden_states + (hidden_states,)
 
         if not return_dict:
@@ -813,18 +886,23 @@ class GPNStarEncoder(RoFormerEncoder):
 
 @dataclass
 class BaseModelOutputWithRowAndColAttentions(ModelOutput):
-    last_hidden_state: torch.FloatTensor = None
-    past_key_values: tuple[tuple[torch.FloatTensor]] | None = None
-    hidden_states: tuple[torch.FloatTensor, ...] | None = None
-    row_attentions: tuple[torch.FloatTensor, ...] | None = None
-    col_attentions: tuple[torch.FloatTensor, ...] | None = None
+    last_hidden_state: Tensor | None = None
+    past_key_values: tuple[Any, ...] | None = None
+    hidden_states: tuple[Tensor, ...] | None = None
+    row_attentions: tuple[Tensor, ...] | None = None
+    col_attentions: tuple[Tensor, ...] | None = None
 
 
 class GPNStarPreTrainedModel(PreTrainedModel):
     config_class = GPNStarConfig
     base_model_prefix = "model"
 
-    def save_pretrained(self, save_directory, *args, **kwargs):
+    def save_pretrained(
+        self,
+        save_directory: str | os.PathLike[str],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         """Save a portable checkpoint with its required phylogenetic assets."""
         source_dir = self.config.phylo_dist_path
         if not _contains_phylo_dist_files(source_dir):
@@ -851,15 +929,15 @@ class GPNStarPreTrainedModel(PreTrainedModel):
     @classmethod
     def from_pretrained(
         cls,
-        pretrained_model_name_or_path,
-        *model_args,
-        config=None,
-        **kwargs,
-    ):
+        pretrained_model_name_or_path: str | os.PathLike[str],
+        *model_args: Any,
+        config: GPNStarConfig | None = None,
+        **kwargs: Any,
+    ) -> Self:
         """Load a checkpoint and its bundled phylogenetic-distance assets."""
         explicit_path = kwargs.pop("phylo_dist_path", None)
         if config is None:
-            hub_kwargs = {
+            hub_kwargs: dict[str, Any] = {
                 key: kwargs[key]
                 for key in (
                     "cache_dir",
@@ -872,7 +950,7 @@ class GPNStarPreTrainedModel(PreTrainedModel):
                 )
                 if key in kwargs
             }
-            config_kwargs = kwargs.copy()
+            config_kwargs: dict[str, Any] = kwargs.copy()
             for key in ("torch_dtype", "dtype"):
                 if config_kwargs.get(key) == "auto":
                     config_kwargs.pop(key)
@@ -886,7 +964,7 @@ class GPNStarPreTrainedModel(PreTrainedModel):
             for key in ("torch_dtype", "dtype", "quantization_config"):
                 if kwargs.get(key) is not None:
                     unused_kwargs[key] = kwargs[key]
-            kwargs = {**hub_kwargs, **unused_kwargs}
+            kwargs = {**hub_kwargs, **dict(unused_kwargs)}
             commit_hash = getattr(config, "_commit_hash", None)
             if commit_hash is not None:
                 kwargs["_commit_hash"] = commit_hash
@@ -904,7 +982,7 @@ class GPNStarPreTrainedModel(PreTrainedModel):
             **kwargs,
         )
 
-    def _init_weights(self, module):
+    def _init_weights(self, module: nn.Module) -> None:
         """Initialize the weights"""
         if isinstance(module, nn.Linear):
             # Slightly different from the TF version which uses truncated_normal for initialization
@@ -922,13 +1000,15 @@ class GPNStarPreTrainedModel(PreTrainedModel):
             module.bias.data.zero_()
             module.weight.data.fill_(1.0)
 
-    def _set_gradient_checkpointing(self, module, value=False):
+    def _set_gradient_checkpointing(
+        self, module: nn.Module, value: bool = False
+    ) -> None:
         if isinstance(module, RoFormerEncoder):
             module.gradient_checkpointing = value
 
 
 class GPNStarPhyloInfo:
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         # Four variables extracted from the phylogenetic tree
         # Pairwise distance (N, N)
         # Distance to MRCA of the clade (N,)
@@ -936,12 +1016,15 @@ class GPNStarPhyloInfo:
         # Clade labels (N,)
 
         # Read
+        if config.phylo_dist_path is None:
+            raise ValueError("phylo_dist_path is required")
+        phylo_dist_path = config.phylo_dist_path
         self.phylo_dist_pairwise = torch.tensor(
-            np.load(config.phylo_dist_path + "/pairwise.npy"),
+            np.load(phylo_dist_path + "/pairwise.npy"),
             device="cpu",
         )
         self.in_clade_phylo_dist = torch.tensor(
-            np.load(config.phylo_dist_path + "/in_clade.npy"),
+            np.load(phylo_dist_path + "/in_clade.npy"),
             device="cpu",
         )
 
@@ -961,9 +1044,12 @@ class GPNStarPhyloInfo:
         self.max_evol_dist = self.phylo_dist_pairwise.max().item()
 
     @staticmethod
-    def cluster_clades(phylo_dist_pairwise, threshold):
+    def cluster_clades(
+        phylo_dist_pairwise: Float[Tensor, "species other_species"],
+        threshold: float,
+    ) -> dict[int, set[int]]:
         N = phylo_dist_pairwise.shape[0]
-        G = nx.Graph()
+        G: nx.Graph[int] = nx.Graph()
         G.add_nodes_from(range(N))
         for i in range(N):
             for j in range(i + 1, N):
@@ -976,7 +1062,7 @@ class GPNStarPhyloInfo:
 
 
 class GPNStarModel(GPNStarPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__(config)
         self.config = config
         self.phylo_info = GPNStarPhyloInfo(config)
@@ -990,12 +1076,14 @@ class GPNStarModel(GPNStarPreTrainedModel):
 
     def forward(
         self,
-        input_ids=None,
-        source_ids=None,
-        target_species=None,
-        output_attentions=False,
-        **kwargs,
-    ):
+        input_ids: Int[Tensor, "batch position target"] | None = None,
+        source_ids: Int[Tensor, "batch position species"] | None = None,
+        target_species: Int[Tensor, "batch target"] | None = None,
+        output_attentions: bool = False,
+        **kwargs: Any,
+    ) -> BaseModelOutputWithRowAndColAttentions | tuple[Any, ...]:
+        if input_ids is None or source_ids is None or target_species is None:
+            raise ValueError("input_ids, source_ids, and target_species are required")
         hidden_states = self.target_embedding(
             input_ids=input_ids,
         )  # (B, L, T, H)
@@ -1040,7 +1128,11 @@ class GPNStarModel(GPNStarPreTrainedModel):
         return x
 
     @staticmethod
-    def compute_clade_means(A, indices, C):
+    def compute_clade_means(
+        A: Float[Tensor, "batch target species"],
+        indices: Int[Tensor, "... species"],
+        C: int,
+    ) -> Float[Tensor, "batch target clade"]:
         B, T, N = A.shape
         A_flat = A.reshape(-1, N)  # Shape: (B*T, N)
         indices_expanded = indices.unsqueeze(0).expand(
@@ -1057,7 +1149,13 @@ class GPNStarModel(GPNStarPreTrainedModel):
         return means
 
 
-def compute_loss(logits, labels, output_probs, loss_weight, vocab_size):
+def compute_loss(
+    logits: Float[Tensor, "... nucleotide"],
+    labels: Int[Tensor, "..."] | None,
+    output_probs: Float[Tensor, "... nucleotide"] | None,
+    loss_weight: Float[Tensor, "..."] | None,
+    vocab_size: int,
+) -> Float[Tensor, ""] | None:
     loss = None
     if labels is not None and loss_weight is None:
         loss_fct = CrossEntropyLoss()
@@ -1074,6 +1172,8 @@ def compute_loss(logits, labels, output_probs, loss_weight, vocab_size):
         loss = (loss * loss_weight).sum() / loss_weight.sum()
 
     elif output_probs is not None:
+        if loss_weight is None:
+            raise ValueError("loss_weight is required with soft output probabilities")
         loss_fct = CrossEntropyLoss(reduction="none")
         output_probs = output_probs.view(-1, vocab_size)
         exclude = (output_probs == 0.0).all(dim=-1)
@@ -1093,7 +1193,7 @@ class GPNStarForMaskedLM(GPNStarPreTrainedModel):
         "cls.predictions.decoder.bias": "cls.predictions.bias",
     }
 
-    def __init__(self, config):
+    def __init__(self, config: GPNStarConfig) -> None:
         super().__init__(config)
 
         self.model = GPNStarModel(config)
@@ -1102,7 +1202,13 @@ class GPNStarForMaskedLM(GPNStarPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def forward(self, labels=None, output_probs=None, loss_weight=None, **kwargs):
+    def forward(
+        self,
+        labels: Int[Tensor, "..."] | None = None,
+        output_probs: Float[Tensor, "... nucleotide"] | None = None,
+        loss_weight: Float[Tensor, "..."] | None = None,
+        **kwargs: Any,
+    ) -> MaskedLMOutput:
         hidden_state = self.model(**kwargs).last_hidden_state
         logits = self.cls(hidden_state)
         loss = compute_loss(

--- a/src/gpn/star/train.py
+++ b/src/gpn/star/train.py
@@ -46,7 +46,12 @@ logger = logging.getLogger(__name__)
 class DataCollatorForLanguageModelingSimplified:
     """Apply clade-aware masking to equal-length GPN-Star examples."""
 
-    def __init__(self, tokenizer, clades, mlm_probability=0.15):
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        clades: Int[np.ndarray, "... species"],
+        mlm_probability: float = 0.15,
+    ) -> None:
         self.gpn_tokenizer = tokenizer
         self.clades = clades
         self.mlm_probability = mlm_probability

--- a/src/gpn/star/utils.py
+++ b/src/gpn/star/utils.py
@@ -1,13 +1,18 @@
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import torch
 import torch.nn.functional as F
+from jaxtyping import Bool, Float, Int, Num
 from numpy.lib.stride_tricks import sliding_window_view
+from torch import Tensor
 
 
-def max_smooth(arr, window_size):
+def max_smooth(
+    arr: Num[np.ndarray, "batch position"], window_size: int
+) -> Num[np.ndarray, "batch position"]:
     # assert window_size is odd
     assert window_size % 2 == 1
 
@@ -26,7 +31,10 @@ def max_smooth(arr, window_size):
     return np.max(windowed_arr, axis=-1).reshape(arr.shape)
 
 
-def calculate_clade_avg_nuc_freq(T, labels):
+def calculate_clade_avg_nuc_freq(
+    T: Int[Tensor, "batch position species nucleotide"],
+    labels: Int[Tensor, "... species"],
+) -> Float[Tensor, "batch position nucleotide"]:
     C = labels.unique().size(0)
 
     labels_onehot = F.one_hot(labels, num_classes=C).float()
@@ -39,7 +47,9 @@ def calculate_clade_avg_nuc_freq(T, labels):
     return avg_freqs
 
 
-def sample_nuc_from_freq(avg_freqs, N):
+def sample_nuc_from_freq(
+    avg_freqs: Float[Tensor, "batch position nucleotide"], N: int
+) -> Int[Tensor, "batch position sample"]:
     probs = avg_freqs / avg_freqs.sum(dim=2, keepdim=True)  # Shape: (B, L, V)
     B, L, V = probs.shape
 
@@ -52,7 +62,11 @@ def sample_nuc_from_freq(avg_freqs, N):
     return samples
 
 
-def get_all_species_mask(clade_mask, clade_indices, species_clade_indices):
+def get_all_species_mask(
+    clade_mask: Bool[Tensor, "batch position selected_clade"],
+    clade_indices: Int[Tensor, "batch selected_clade"],
+    species_clade_indices: Int[Tensor, "... species"],
+) -> Bool[Tensor, "batch position species"]:
     N = species_clade_indices.shape[0]
 
     clade_indices_expanded = clade_indices.unsqueeze(2)  # Shape: (B, C, 1)
@@ -77,7 +91,7 @@ def get_all_species_mask(clade_mask, clade_indices, species_clade_indices):
     return species_mask
 
 
-def find_directory_sum_paths(path_str):
+def find_directory_sum_paths(path_str: str | Path) -> dict[int, str]:
     # Preserve the logical directory name: SCF layouts commonly use a `100`
     # symlink whose target is named `99` (99 aligned species plus the target).
     root = Path(path_str).expanduser().absolute()
@@ -111,7 +125,7 @@ def find_directory_sum_paths(path_str):
     }
 
 
-def normalize_logits(logits):
+def normalize_logits(logits: pd.DataFrame) -> pd.DataFrame:
     logits_array = logits.values
 
     exp_logits = np.exp(logits_array)
@@ -122,7 +136,7 @@ def normalize_logits(logits):
     return pd.DataFrame(normalized_logits, columns=logits.columns, index=logits.index)
 
 
-def get_entropy(logits):
+def get_entropy(logits: pd.DataFrame) -> np.ndarray:
     logits_array = logits.values
 
     probs = np.exp(logits_array)
@@ -131,7 +145,11 @@ def get_entropy(logits):
     return entropy
 
 
-def get_llr(logits, ref, alt):
+def get_llr(
+    logits: pd.DataFrame,
+    ref: Sequence[str],
+    alt: Sequence[str],
+) -> np.ndarray:
     ref_logits = logits.values[
         np.arange(len(ref)), [logits.columns.get_loc(r) for r in ref]
     ]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+import torch
+
+from gpn.embeddings import OneHotAuxEmbedding
+
+
+def test_one_hot_embedding_accepts_continuous_auxiliary_features() -> None:
+    config = SimpleNamespace(
+        vocab_size=6,
+        n_aux_features=2,
+        hidden_size=8,
+        aux_features_vocab_size=None,
+    )
+    embedding = OneHotAuxEmbedding(config)
+    input_ids = torch.tensor([[1, 2]])
+    auxiliary = torch.tensor([[[0.25, 0.75], [0.5, 0.5]]])
+
+    actual = embedding(input_ids=input_ids, aux_features=auxiliary)
+
+    assert actual.shape == (1, 2, 8)
+    torch.testing.assert_close(actual[..., 6:8], auxiliary)

--- a/tests/test_release_governance.py
+++ b/tests/test_release_governance.py
@@ -192,7 +192,16 @@ def test_transformers_version_is_pinned_to_the_validated_runtime() -> None:
 
 def test_static_quality_checks_cover_the_full_package() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())
-    assert project["tool"]["mypy"]["files"] == ["src/gpn"]
+    mypy = project["tool"]["mypy"]
+    assert mypy["files"] == ["src/gpn"]
+    assert mypy["strict"] is True
+    assert mypy["follow_imports"] == "skip"
+    assert {
+        "disallow_subclassing_any",
+        "disallow_untyped_calls",
+        "disallow_untyped_decorators",
+        "warn_return_any",
+    } == {name for name, value in mypy.items() if value is False}
 
     pre_commit = (ROOT / ".pre-commit-config.yaml").read_text()
     assert "- id: ruff-check\n" in pre_commit

--- a/tests/test_release_governance.py
+++ b/tests/test_release_governance.py
@@ -160,6 +160,7 @@ def test_release_workflow_uses_locked_isolated_trusted_publishing() -> None:
     workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
 
     assert "permissions:\n  contents: read" in workflow
+    assert "if: startsWith(github.event.release.tag_name, 'v')" in workflow
     assert "persist-credentials: false" in workflow
     assert "--only-group release --no-install-project" in workflow
     assert "uv build --no-build-isolation" in workflow

--- a/tests/test_release_governance.py
+++ b/tests/test_release_governance.py
@@ -51,17 +51,16 @@ def test_external_mutation_ledger_covers_release_boundary() -> None:
     applied = {action["id"]: action for action in ledger["applied"]}
 
     assert set(pending) == {
-        "protect-main",
-        "enable-security-features",
-        "publish-analysis-archive",
         "publish-gpn-0-9-0",
     }
     assert {
         "pypi-trusted-publisher-binding",
         "merge-modernization-pr",
         "publish-read-the-docs",
+        "protect-main",
+        "enable-security-features",
+        "publish-analysis-archive",
     } <= set(applied)
-    assert pending["protect-main"]["source"] == "release/main-ruleset.json"
     assert pending["publish-gpn-0-9-0"]["source"] == "release/0.9.0/review.md"
     assert pending["publish-gpn-0-9-0"]["disposition"] == "approval_ready"
 
@@ -90,9 +89,6 @@ def test_final_approval_has_an_exact_bounded_action_set() -> None:
     }
 
     assert ready_ids == {
-        "protect-main",
-        "enable-security-features",
-        "publish-analysis-archive",
         "publish-gpn-0-9-0",
     }
 
@@ -106,8 +102,8 @@ def test_hub_audit_is_outside_this_release() -> None:
 
 def test_archive_mutation_identifies_tag_object_and_peeled_commit() -> None:
     ledger = _json("external-mutations.json")
-    pending = {action["id"]: action for action in ledger["pending"]}
-    archive = pending["publish-analysis-archive"]
+    applied = {action["id"]: action for action in ledger["applied"]}
+    archive = applied["publish-analysis-archive"]
 
     assert "tag object 312a6c70de6700e729bcea4c9a67ab42a72f05f7" in archive["targets"]
     assert "commit 30dee6cf45849dfdcfc043ca8baf44fd6ba51d74" in archive["targets"]
@@ -128,6 +124,7 @@ def test_proposed_main_ruleset_matches_ci_and_solo_maintenance() -> None:
     pull_request = rules["pull_request"]["parameters"]
     assert pull_request["required_approving_review_count"] == 0
     assert pull_request["require_code_owner_review"] is False
+    assert pull_request["require_extra_approval_for_unattributed_changes"] is False
     assert pull_request["require_last_push_approval"] is False
     assert pull_request["required_review_thread_resolution"] is True
     assert pull_request["allowed_merge_methods"] == ["squash"]
@@ -143,12 +140,9 @@ def test_proposed_main_ruleset_matches_ci_and_solo_maintenance() -> None:
         "Package",
     }
     protect_main = next(
-        action for action in ledger["pending"] if action["id"] == "protect-main"
+        action for action in ledger["applied"] if action["id"] == "protect-main"
     )
-    assert (
-        "the final CI workflow has reported all four required contexts named in "
-        "release/main-ruleset.json on a pull request" in protect_main["preconditions"]
-    )
+    assert "songlab-cal/gpn:ruleset:21510261" in protect_main["targets"]
     ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
     for context in required:
         assert f"name: {context}" in ci
@@ -207,10 +201,10 @@ def test_release_version_metadata_is_consistent() -> None:
     changelog = (ROOT / "CHANGELOG.md").read_text()
     assert version == "0.9.0"
     assert locked_project["version"] == version
-    assert f"## {version} — Unreleased\n" in changelog
+    assert f"## {version} — 2026-08-25\n" in changelog
 
 
-def test_release_review_uses_one_pull_request() -> None:
+def test_release_review_records_the_modernization_boundary() -> None:
     review = (RELEASE_DIR / "0.9.0" / "review.md").read_text()
     runbook = (ROOT / "docs" / "development" / "release.md").read_text()
     release_readme = (RELEASE_DIR / "README.md").read_text()
@@ -222,7 +216,7 @@ def test_release_review_uses_one_pull_request() -> None:
     )
 
     assert "pull/100" in review
-    assert "690557d949309cf4f4234554888bb5421c49aede" in review
+    assert "305c29a1db9bf327c7d2bc049b8800d8dc131fdb" in review
     assert "pull/96" not in review
     assert "pull/98" not in review
     assert "pull/99" not in review

--- a/tests/test_release_governance.py
+++ b/tests/test_release_governance.py
@@ -190,6 +190,18 @@ def test_transformers_version_is_pinned_to_the_validated_runtime() -> None:
     assert '--no-deps "transformers==' not in ci
 
 
+def test_static_quality_checks_cover_the_full_package() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    assert project["tool"]["mypy"]["files"] == ["src/gpn"]
+
+    pre_commit = (ROOT / ".pre-commit-config.yaml").read_text()
+    assert "- id: ruff-check\n" in pre_commit
+    assert "- id: ruff-format\n" in pre_commit
+    assert "name: mypy full package" in pre_commit
+    assert "pass_filenames: false" in pre_commit
+    assert "files: ^(pyproject\\.toml|src/gpn/.*\\.py)$" in pre_commit
+
+
 def test_release_version_metadata_is_consistent() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())
     lock = tomllib.loads((ROOT / "uv.lock").read_text())

--- a/uv.lock
+++ b/uv.lock
@@ -684,6 +684,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "twine" },
+    { name = "types-networkx" },
     { name = "types-pyyaml" },
 ]
 docs = [
@@ -739,6 +740,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3" },
     { name = "ruff", specifier = ">=0.16.3" },
     { name = "twine", specifier = ">=6" },
+    { name = "types-networkx", specifier = ">=3.6" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 docs = [
@@ -2581,6 +2583,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
+]
+
+[[package]]
+name = "types-networkx"
+version = "3.6.1.20260728"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/8e/9c80373fd5a33c82ac25cbe868afae25c2babf050b65468464933c5f2854/types_networkx-3.6.1.20260728.tar.gz", hash = "sha256:f193e4fc6a41c973c7d687fa3c12f8008d8e7dcd22b0ab62f0300cc47b65eb28", size = 75720, upload-time = "2026-07-28T04:51:49.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/4a/619f72e3f149b9291c1537ff3aceaecef8ed36877db13ea3698b2841663d/types_networkx-3.6.1.20260728-py3-none-any.whl", hash = "sha256:0be72ff7625dbdfcd2d76ed7662de96987d0d5433b7055c320065d5b3621f9f6", size = 167078, upload-time = "2026-07-28T04:51:48.071Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Exact candidate

This PR is the single final review surface for GPN 0.9.0.

- Base commit: `305c29a1db9bf327c7d2bc049b8800d8dc131fdb`
- Candidate head: `8afda49cfa6b21616813239219bbb12cd06fdaa2`
- Candidate tree: `8595b87d599c3e7fcbfc599352b5c6ab9e2f8350`
- Package version: `0.9.0`

The previous candidate binding is obsolete. Approval and publication must refer
to the exact head and tree above.

## What this completes

- Finalizes the maintained package, tests, documentation, release evidence, and
  GPN/GPN-Star training recipes established by the modernization work.
- Enforces Ruff linting, Ruff formatting, and strict mypy across every Python
  module under `src/gpn`.
- Adds semantic jaxtyping annotations across tensor- and array-facing model,
  data, training, inference, and scoring code.
- Retains GPN and GPN-Star training and inference; GPN-MSA, PhyloGPN, and the
  Sorghum gene-expression model remain inference-only.
- Keeps dataset-building and historical analysis code outside `main`.
- Records the exact remaining release mutation: publish `gpn==0.9.0` through
  the configured PyPI Trusted Publisher only after explicit maintainer approval.

Issues #81 and #108 remain explicitly deferred until after 0.9.0 and are not
part of this candidate.

## Exact validation evidence

- `uv run pre-commit run --all-files`: passed, including full-package Ruff lint,
  Ruff format, strict mypy, dependency placement, and lockfile checks.
- Offline suite: **234 passed, 6 skipped**. The five published-model tests are
  deliberately opt-in; the sixth skip is the CUDA-only GPN-Star training test.
- Published-model suite on Slurm job `3475912`: **239 passed, 1 skipped** on the
  exact archived candidate source. All five pinned Hugging Face model checks
  passed; only the CUDA-only training test was skipped.
- `python docs/prepare_notebooks.py` and strict Sphinx 9.1.0 build with
  `-E -n -W --keep-going`: passed.
- Required GitHub CI run
  [32922193244](https://github.com/songlab-cal/gpn/actions/runs/32922193244):
  **Quality**, **Python 3.13**, **Documentation**, and **Package** passed. The
  Package job rebuilds the wheel from the source distribution and smoke-tests a
  clean installed wheel outside the checkout.
- Two local builds with `SOURCE_DATE_EPOCH=1787710645` were byte-identical:
  - `gpn-0.9.0.tar.gz`: `f342f35adf359a5688c9d204d3166907e13a40fb72852bf128c28f59a9b6c5e7`
  - `gpn-0.9.0-py3-none-any.whl`: `f8c224a1e8bf38c7f35ac7d30c10dd3d095bd882b915495bd0251b572f468b0b`
- `twine check` and `check-wheel-contents`: passed.
- The final wheel was installed with dependencies into a new Python 3.13 virtual
  environment outside the checkout; `gpn --version`, `gpn --help`, package
  import, and explicit AutoClass registration passed.
- Independent complete-diff review found one annotation-contract issue for
  continuous auxiliary features. It is fixed with a regression test, and the
  reviewer confirmed the exact final head/tree with no remaining actionable
  findings.

Residual non-blocking risks are the CUDA-only GPN-Star training test skipped on
CPU, the documented dynamic-third-party boundary around strict mypy, and an
upstream PyTorch SDP deprecation warning.

## Approval boundary

Merging does not itself authorize a tag, GitHub Release, or PyPI publication.
After independent review, the maintainer must explicitly approve this exact
head/tree and the `publish-gpn-0-9-0` action. A squash merge must produce the
same tree; publication stops if it differs.

Progresses #82 and #86.
