### PR TITLE
Record GPN 0.9.0 publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 GPN follows Semantic Versioning. Package releases are distinct from immutable
 Hugging Face model revisions.
 
-## 0.9.0 — 2026-08-25
+## 0.9.0 — 2026-08-26
 
 ### Added
 

--- a/release/0.9.0/review.md
+++ b/release/0.9.0/review.md
@@ -1,8 +1,6 @@
 # GPN 0.9.0 review packet
 
-Status: **final release candidate; version 0.9.0 remains unreleased. Publishing
-the release still requires explicit approval of the exact final PR head and
-tree.**
+Status: **published on 2026-08-26 from the exact approved final PR tree.**
 
 The single pull request, [#100](https://github.com/songlab-cal/gpn/pull/100), was
 the binding review surface for the complete modernization. It was squash-merged
@@ -28,6 +26,23 @@ release binding.
 - GPN-MSA: deprecated inference only
 - Supported inference families: GPN, GPN-MSA, PhyloGPN, and GPN-Star; supported
   GPN checkpoints include the Sorghum gene-expression fine-tune
+
+## Publication result
+
+- Release commit: `007768a31618fa76c2c3db953e69cc2013f5a79c`
+- Release tree: `8595b87d599c3e7fcbfc599352b5c6ab9e2f8350`
+- Annotated tag object: `37ac68ce7b1d8b7365380401aa89993017864024`
+- GitHub Release: <https://github.com/songlab-cal/gpn/releases/tag/v0.9.0>
+- PyPI release: <https://pypi.org/project/gpn/0.9.0/>
+- Trusted Publishing workflow: <https://github.com/songlab-cal/gpn/actions/runs/32965467513>
+- Wheel SHA-256: `7a175368577a851593bacca774caa80da3185aea375a0ab25fcf12147ecddd47`
+- Source distribution SHA-256: `ad3c4ed9cc1013b26675b55f9f81b14329b5c4ef2344db1dd5d7725b52442316`
+
+The two published distributions match the immutable workflow artifact and pass
+PyPI attestation verification against `songlab-cal/gpn`. A clean Python 3.13 CPU
+installation from PyPI reports version `0.9.0`; the CLI and explicit AutoClass
+registration smoke tests pass. The hosted documentation remains available at
+<https://gpn.readthedocs.io/en/latest/>.
 
 ## Evidence reviewed
 

--- a/release/0.9.0/review.md
+++ b/release/0.9.0/review.md
@@ -38,11 +38,12 @@ release binding.
 - Wheel SHA-256: `7a175368577a851593bacca774caa80da3185aea375a0ab25fcf12147ecddd47`
 - Source distribution SHA-256: `ad3c4ed9cc1013b26675b55f9f81b14329b5c4ef2344db1dd5d7725b52442316`
 
-The two published distributions match the immutable workflow artifact and pass
-PyPI attestation verification against `songlab-cal/gpn`. A clean Python 3.13 CPU
-installation from PyPI reports version `0.9.0`; the CLI and explicit AutoClass
-registration smoke tests pass. The hosted documentation remains available at
-<https://gpn.readthedocs.io/en/latest/>.
+The remote annotated tag object peels to the release commit above, whose tree is
+the exact approved release tree. The two published distributions match the
+immutable workflow artifact and pass PyPI attestation verification against
+`songlab-cal/gpn`. A clean Python 3.13 CPU installation from PyPI reports version
+`0.9.0`; the CLI and explicit AutoClass registration smoke tests pass. The hosted
+documentation remains available at <https://gpn.readthedocs.io/en/latest/>.
 
 ## Evidence reviewed
 

--- a/release/external-mutations.json
+++ b/release/external-mutations.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./external-mutations.schema.json",
   "schema_version": 1,
-  "recorded_at": "2026-08-25",
+  "recorded_at": "2026-08-26",
   "repository": "songlab-cal/gpn",
   "applied": [
     {
@@ -135,39 +135,25 @@
         "the tag peels to commit 30dee6cf45849dfdcfc043ca8baf44fd6ba51d74",
         "the public release states that the archived code is historical and unsupported"
       ]
-    }
-  ],
-  "pending": [
+    },
     {
       "id": "publish-gpn-0-9-0",
-      "system": "github",
-      "authorization": "explicit_final_maintainer_approval",
-      "disposition": "approval_ready",
-      "operation": "publish GitHub Release v0.9.0 from the exact approved main commit, triggering the Trusted Publishing workflow",
+      "system": "pypi",
+      "operation": "published GPN 0.9.0 through the approved GitHub Release and PyPI Trusted Publishing workflow",
       "targets": [
-        "songlab-cal/gpn@v0.9.0",
-        "https://pypi.org/project/gpn/0.9.0/"
+        "https://github.com/songlab-cal/gpn/releases/tag/v0.9.0",
+        "https://pypi.org/project/gpn/0.9.0/",
+        "tag object 37ac68ce7b1d8b7365380401aa89993017864024",
+        "commit 007768a31618fa76c2c3db953e69cc2013f5a79c"
       ],
-      "source": "release/0.9.0/review.md",
-      "depends_on": [
-        "merge-modernization-pr",
-        "protect-main",
-        "publish-analysis-archive"
-      ],
-      "preconditions": [
-        "the final release PR body records the exact approved head and tree and the maintainer approves that candidate",
-        "the resulting main commit is recorded after squash-merging the final release PR and has exactly the approved tree",
-        "the package version is exactly 0.9.0 and the tag target is the approved main commit",
-        "the final review packet records a clean Python 3.13 install plus wheel and sdist hashes",
-        "the release workflow and pypi environment are unchanged from the reviewed versions"
-      ],
-      "verification": [
-        "the workflow publishes exactly one wheel and one source distribution with PyPI attestations",
-        "a clean CPU install on Python 3.13 reproduces the documented package and model-registration smoke tests"
-      ],
-      "failure_response": [
-        "never overwrite artifacts or reuse the version; stop downstream writes, document the incident, yank if appropriate, and prepare a patch release"
+      "evidence": [
+        "release workflow 32965467513 completed successfully from refs/tags/v0.9.0",
+        "wheel sha256 7a175368577a851593bacca774caa80da3185aea375a0ab25fcf12147ecddd47",
+        "sdist sha256 ad3c4ed9cc1013b26675b55f9f81b14329b5c4ef2344db1dd5d7725b52442316",
+        "both published files matched the immutable workflow artifact and passed PyPI attestation verification for songlab-cal/gpn",
+        "a clean Python 3.13 CPU installation from PyPI reported version 0.9.0 and passed CLI and explicit AutoClass-registration smoke tests"
       ]
     }
-  ]
+  ],
+  "pending": []
 }

--- a/release/external-mutations.json
+++ b/release/external-mutations.json
@@ -147,6 +147,7 @@
         "commit 007768a31618fa76c2c3db953e69cc2013f5a79c"
       ],
       "evidence": [
+        "the remote annotated tag object 37ac68ce7b1d8b7365380401aa89993017864024 peels to commit 007768a31618fa76c2c3db953e69cc2013f5a79c, whose tree is the approved tree 8595b87d599c3e7fcbfc599352b5c6ab9e2f8350",
         "release workflow 32965467513 completed successfully from refs/tags/v0.9.0",
         "wheel sha256 7a175368577a851593bacca774caa80da3185aea375a0ab25fcf12147ecddd47",
         "sdist sha256 ad3c4ed9cc1013b26675b55f9f81b14329b5c4ef2344db1dd5d7725b52442316",

--- a/tests/test_release_governance.py
+++ b/tests/test_release_governance.py
@@ -34,10 +34,10 @@ def test_external_mutation_ledger_conforms_to_schema() -> None:
     deferred = [
         action for action in ledger["pending"] if action["disposition"] == "deferred"
     ]
-    assert ready
-    assert {action["authorization"] for action in ready} == {
-        "explicit_final_maintainer_approval"
-    }
+    if ready:
+        assert {action["authorization"] for action in ready} == {
+            "explicit_final_maintainer_approval"
+        }
     if deferred:
         assert {action["authorization"] for action in deferred} == {
             "separate_future_maintainer_approval"
@@ -50,9 +50,7 @@ def test_external_mutation_ledger_covers_release_boundary() -> None:
     pending = {action["id"]: action for action in ledger["pending"]}
     applied = {action["id"]: action for action in ledger["applied"]}
 
-    assert set(pending) == {
-        "publish-gpn-0-9-0",
-    }
+    assert not pending
     assert {
         "pypi-trusted-publisher-binding",
         "merge-modernization-pr",
@@ -60,9 +58,13 @@ def test_external_mutation_ledger_covers_release_boundary() -> None:
         "protect-main",
         "enable-security-features",
         "publish-analysis-archive",
+        "publish-gpn-0-9-0",
     } <= set(applied)
-    assert pending["publish-gpn-0-9-0"]["source"] == "release/0.9.0/review.md"
-    assert pending["publish-gpn-0-9-0"]["disposition"] == "approval_ready"
+
+    publication = applied["publish-gpn-0-9-0"]
+    assert "https://pypi.org/project/gpn/0.9.0/" in publication["targets"]
+    assert any("wheel sha256" in item for item in publication["evidence"])
+    assert any("sdist sha256" in item for item in publication["evidence"])
 
     for action in ledger["pending"]:
         source = action.get("source")
@@ -88,9 +90,7 @@ def test_final_approval_has_an_exact_bounded_action_set() -> None:
         if action["disposition"] == "approval_ready"
     }
 
-    assert ready_ids == {
-        "publish-gpn-0-9-0",
-    }
+    assert not ready_ids
 
 
 def test_hub_audit_is_outside_this_release() -> None:
@@ -223,7 +223,7 @@ def test_release_version_metadata_is_consistent() -> None:
     changelog = (ROOT / "CHANGELOG.md").read_text()
     assert version == "0.9.0"
     assert locked_project["version"] == version
-    assert f"## {version} — 2026-08-25\n" in changelog
+    assert f"## {version} — 2026-08-26\n" in changelog
 
 
 def test_release_review_records_the_modernization_boundary() -> None:

--- a/tests/test_release_governance.py
+++ b/tests/test_release_governance.py
@@ -65,6 +65,13 @@ def test_external_mutation_ledger_covers_release_boundary() -> None:
     assert "https://pypi.org/project/gpn/0.9.0/" in publication["targets"]
     assert any("wheel sha256" in item for item in publication["evidence"])
     assert any("sdist sha256" in item for item in publication["evidence"])
+    assert (
+        "the remote annotated tag object "
+        "37ac68ce7b1d8b7365380401aa89993017864024 peels to commit "
+        "007768a31618fa76c2c3db953e69cc2013f5a79c, whose tree is the "
+        "approved tree 8595b87d599c3e7fcbfc599352b5c6ab9e2f8350"
+        in publication["evidence"]
+    )
 
     for action in ledger["pending"]:
         source = action.get("source")


### PR DESCRIPTION
## Outcome

Record the completed GPN 0.9.0 publication after the exact reviewed release candidate was tagged and published through Trusted Publishing.

## Publication evidence

- Release: https://github.com/songlab-cal/gpn/releases/tag/v0.9.0
- PyPI: https://pypi.org/project/gpn/0.9.0/
- Workflow: https://github.com/songlab-cal/gpn/actions/runs/32965467513
- Release commit: `007768a31618fa76c2c3db953e69cc2013f5a79c`
- Release tree: `8595b87d599c3e7fcbfc599352b5c6ab9e2f8350`
- Annotated tag object: `37ac68ce7b1d8b7365380401aa89993017864024`
- Wheel SHA-256: `7a175368577a851593bacca774caa80da3185aea375a0ab25fcf12147ecddd47`
- Source distribution SHA-256: `ad3c4ed9cc1013b26675b55f9f81b14329b5c4ef2344db1dd5d7725b52442316`

The PyPI files match the immutable workflow artifact byte-for-byte. Both distributions pass PyPI attestation verification against `songlab-cal/gpn`. A clean Python 3.13 CPU install from PyPI reports `0.9.0`; CLI help/version and explicit AutoClass registration pass. Read the Docs returns HTTP 200.

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest` — 234 passed, 6 skipped
- `python docs/prepare_notebooks.py`
- `uv run sphinx-build -n -W --keep-going -b html docs docs/_build/html`

This PR contains records and their governance assertions only; it does not alter the already-published artifacts. Issues #81 and #108 remain open for post-release work.

Closes #82
Closes #86
